### PR TITLE
Added PHP 8.0 support #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /coveralls-upload.json
 /phpunit.xml
 /vendor/
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,32 +12,34 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=lowest
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=latest
-    - php: 7.3
+    - php: nightly
       env:
         - DEPS=lowest
-    - php: 7.3
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - php: nightly
       env:
         - DEPS=latest
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
 
 install:
-  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
+  - travis_retry composer install $COMPOSER_ARGS
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-router": "^3.0",
         "psr/container": "^1.0",
@@ -38,9 +38,10 @@
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-diactoros": "^1.7.1",
-        "malukenho/docheader": "^0.1.6",
-        "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^7.0.2"
+        "malukenho/docheader": "^0.1.8",
+        "mockery/mockery": "^1.4.2",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.4.2"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
-    <testsuites>
-        <testsuite name="mezzio-helpers">
-            <directory>./test</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="mezzio-helpers">
+      <directory>./test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/test/BodyParams/BodyParamsMiddlewareTest.php
+++ b/test/BodyParams/BodyParamsMiddlewareTest.php
@@ -18,9 +18,10 @@ use Mezzio\Helper\BodyParams\StrategyInterface;
 use Mezzio\Helper\Exception\MalformedRequestBodyException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-
+use ReflectionProperty;
 use function fopen;
 use function fwrite;
 use function get_class;
@@ -28,6 +29,8 @@ use function json_encode;
 
 class BodyParamsMiddlewareTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var Stream
      */
@@ -38,7 +41,7 @@ class BodyParamsMiddlewareTest extends TestCase
      */
     private $bodyParams;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->bodyParams = new BodyParamsMiddleware();
 
@@ -274,5 +277,19 @@ class BodyParamsMiddlewareTest extends TestCase
 
         $this->assertInstanceOf(Response::class, $result);
         $this->assertTrue($handlerTriggered);
+    }
+
+    private function assertAttributeSame($expected, $attribute, $object)
+    {
+        $r = new ReflectionProperty($object, $attribute);
+        $r->setAccessible(true);
+        self::assertSame($expected, $r->getValue($object));
+    }
+
+    private function assertAttributeContains($expected, $attribute, $object)
+    {
+        $r = new ReflectionProperty($object, $attribute);
+        $r->setAccessible(true);
+        self::assertContains($expected, $r->getValue($object));
     }
 }

--- a/test/BodyParams/FormUrlEncodedStrategyTest.php
+++ b/test/BodyParams/FormUrlEncodedStrategyTest.php
@@ -12,17 +12,20 @@ namespace MezzioTest\Helper\BodyParams;
 
 use Mezzio\Helper\BodyParams\FormUrlEncodedStrategy;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 
 class FormUrlEncodedStrategyTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var FormUrlEncodedStrategy
      */
     private $strategy;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->strategy = new FormUrlEncodedStrategy();
     }

--- a/test/BodyParams/JsonStrategyTest.php
+++ b/test/BodyParams/JsonStrategyTest.php
@@ -13,17 +13,20 @@ namespace MezzioTest\Helper\BodyParams;
 use Mezzio\Helper\BodyParams\JsonStrategy;
 use Mezzio\Helper\Exception\MalformedRequestBodyException;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 
 class JsonStrategyTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var JsonStrategy
      */
     private $strategy;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->strategy = new JsonStrategy();
     }

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -32,7 +32,7 @@ class ConfigProviderTest extends TestCase
     public function testInvocationReturnsArray() : array
     {
         $config = ($this->provider)();
-        $this->assertInternalType('array', $config);
+        $this->assertIsArray($config);
 
         return $config;
     }
@@ -43,14 +43,14 @@ class ConfigProviderTest extends TestCase
     public function testReturnedArrayContainsDependencies(array $config) : void
     {
         $this->assertArrayHasKey('dependencies', $config);
-        $this->assertInternalType('array', $config['dependencies']);
+        $this->assertIsArray($config['dependencies']);
 
         $this->assertArrayHasKey('invokables', $config['dependencies']);
-        $this->assertInternalType('array', $config['dependencies']['invokables']);
+        $this->assertIsArray($config['dependencies']['invokables']);
         $this->assertArrayHasKey(ServerUrlHelper::class, $config['dependencies']['invokables']);
 
         $this->assertArrayHasKey('factories', $config['dependencies']);
-        $this->assertInternalType('array', $config['dependencies']['factories']);
+        $this->assertIsArray($config['dependencies']['factories']);
         $this->assertArrayHasKey(ServerUrlMiddleware::class, $config['dependencies']['factories']);
         $this->assertArrayHasKey(UrlHelper::class, $config['dependencies']['factories']);
         $this->assertArrayHasKey(UrlHelperMiddleware::class, $config['dependencies']['factories']);

--- a/test/ContentLengthMiddlewareTest.php
+++ b/test/ContentLengthMiddlewareTest.php
@@ -12,6 +12,7 @@ namespace MezzioTest\Helper;
 
 use Mezzio\Helper\ContentLengthMiddleware;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
@@ -19,7 +20,9 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class ContentLengthMiddlewareTest extends TestCase
 {
-    public function setUp()
+    use ProphecyTrait;
+
+    public function setUp(): void
     {
         $this->response = $response = $this->prophesize(ResponseInterface::class);
         $this->request = $request = $this->prophesize(ServerRequestInterface::class)->reveal();

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -39,7 +39,7 @@ class ExceptionTest extends TestCase
      */
     public function testExceptionIsInstanceOfExceptionInterface(string $exception) : void
     {
-        self::assertContains('Exception', $exception);
+        self::assertStringContainsString('Exception', $exception);
         self::assertTrue(is_a($exception, ExceptionInterface::class, true));
     }
 }

--- a/test/ServerUrlMiddlewareFactoryTest.php
+++ b/test/ServerUrlMiddlewareFactoryTest.php
@@ -15,10 +15,13 @@ use Mezzio\Helper\ServerUrlHelper;
 use Mezzio\Helper\ServerUrlMiddleware;
 use Mezzio\Helper\ServerUrlMiddlewareFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 
 class ServerUrlMiddlewareFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testCreatesAndReturnsMiddlewareWhenHelperIsPresentInContainer()
     {
         $helper = $this->prophesize(ServerUrlHelper::class);

--- a/test/ServerUrlMiddlewareTest.php
+++ b/test/ServerUrlMiddlewareTest.php
@@ -15,13 +15,17 @@ use Mezzio\Helper\ServerUrlHelper;
 use Mezzio\Helper\ServerUrlMiddleware;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use ReflectionProperty;
 
 class ServerUrlMiddlewareTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testMiddlewareInjectsHelperWithUri()
     {
         $uri = $this->prophesize(UriInterface::class);
@@ -44,11 +48,8 @@ class ServerUrlMiddlewareTest extends TestCase
         //$this->assertSame($response->reveal(), $test, 'Unexpected return value from middleware');
         $this->assertTrue($invoked, 'next() was not invoked');
 
-        $this->assertAttributeSame(
-            $uri->reveal(),
-            'uri',
-            $helper,
-            'Helper was not injected with URI from request'
-        );
+        $r = new ReflectionProperty($helper, 'uri');
+        $r->setAccessible(true);
+        self::assertSame($uri->reveal(), $r->getValue($helper), 'Helper was not injected with URI from request');
     }
 }

--- a/test/Template/RouteTemplateVariableMiddlewareTest.php
+++ b/test/Template/RouteTemplateVariableMiddlewareTest.php
@@ -16,6 +16,7 @@ use Mezzio\Router\Route;
 use Mezzio\Router\RouteResult;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -23,7 +24,9 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class RouteTemplateVariableMiddlewareTest extends TestCase
 {
-    public function setUp()
+    use ProphecyTrait;
+
+    public function setUp(): void
     {
         $this->request    = $this->prophesize(ServerRequestInterface::class);
         $this->response   = $this->prophesize(ResponseInterface::class);

--- a/test/Template/TemplateVariableContainerMiddlewareTest.php
+++ b/test/Template/TemplateVariableContainerMiddlewareTest.php
@@ -14,13 +14,16 @@ use Mezzio\Helper\Template\TemplateVariableContainer;
 use Mezzio\Helper\Template\TemplateVariableContainerMiddleware;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 class TemplateVariableContainerMiddlewareTest extends TestCase
 {
-    public function setUp()
+    use ProphecyTrait;
+
+    public function setUp(): void
     {
         $this->handler    = $this->prophesize(RequestHandlerInterface::class);
         $this->request    = $this->prophesize(ServerRequestInterface::class);

--- a/test/Template/TemplateVariableContainerTest.php
+++ b/test/Template/TemplateVariableContainerTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class TemplateVariableContainerTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = new TemplateVariableContainer();
     }

--- a/test/UrlHelperFactoryTest.php
+++ b/test/UrlHelperFactoryTest.php
@@ -15,11 +15,15 @@ use Mezzio\Helper\UrlHelper;
 use Mezzio\Helper\UrlHelperFactory;
 use Mezzio\Router\RouterInterface;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
+use ReflectionProperty;
 
 class UrlHelperFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var RouterInterface|ObjectProphecy
      */
@@ -35,7 +39,7 @@ class UrlHelperFactoryTest extends TestCase
      */
     private $factory;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->router = $this->prophesize(RouterInterface::class);
         $this->container = $this->prophesize(ContainerInterface::class);
@@ -95,5 +99,12 @@ class UrlHelperFactoryTest extends TestCase
         $this->assertInstanceOf(UrlHelperFactory::class, $factory);
         $this->assertAttributeSame('/api', 'basePath', $factory);
         $this->assertAttributeSame(Router::class, 'routerServiceName', $factory);
+    }
+
+    private function assertAttributeSame($expected, $attribute, $object)
+    {
+        $r = new ReflectionProperty($object, $attribute);
+        $r->setAccessible(true);
+        self::assertSame($expected, $r->getValue($object));
     }
 }

--- a/test/UrlHelperMiddlewareFactoryTest.php
+++ b/test/UrlHelperMiddlewareFactoryTest.php
@@ -15,17 +15,21 @@ use Mezzio\Helper\UrlHelper;
 use Mezzio\Helper\UrlHelperMiddleware;
 use Mezzio\Helper\UrlHelperMiddlewareFactory;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
+use ReflectionProperty;
 
 class UrlHelperMiddlewareFactoryTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ContainerInterface|ObjectProphecy
      */
     private $container;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->container = $this->prophesize(ContainerInterface::class);
     }
@@ -77,5 +81,12 @@ class UrlHelperMiddlewareFactoryTest extends TestCase
 
         $this->assertInstanceOf(UrlHelperMiddlewareFactory::class, $factory);
         $this->assertAttributeSame(MyUrlHelper::class, 'urlHelperServiceName', $factory);
+    }
+
+    private function assertAttributeSame($expected, $attribute, $object)
+    {
+        $r = new ReflectionProperty($object, $attribute);
+        $r->setAccessible(true);
+        self::assertSame($expected, $r->getValue($object));
     }
 }

--- a/test/UrlHelperMiddlewareTest.php
+++ b/test/UrlHelperMiddlewareTest.php
@@ -15,6 +15,7 @@ use Mezzio\Helper\UrlHelperMiddleware;
 use Mezzio\Router\RouteResult;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -22,12 +23,14 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class UrlHelperMiddlewareTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var UrlHelper|ObjectProphecy
      */
     private $helper;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->helper = $this->prophesize(UrlHelper::class);
     }

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -19,12 +19,16 @@ use Mezzio\Router\RouterInterface;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use ReflectionProperty;
 use stdClass;
 use TypeError;
 
 class UrlHelperTest extends TestCase
 {
+    use ProphecyTrait;
+
     use MockeryPHPUnitIntegration;
 
     /**
@@ -32,7 +36,7 @@ class UrlHelperTest extends TestCase
      */
     private $router;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->router = $this->prophesize(RouterInterface::class);
     }
@@ -392,5 +396,19 @@ class UrlHelperTest extends TestCase
 
         $helper->setRouteResult($result->reveal());
         $this->assertInstanceOf(RouteResult::class, $helper->getRouteResult());
+    }
+
+    private function assertAttributeSame($expected, $attribute, $object)
+    {
+        $r = new ReflectionProperty($object, $attribute);
+        $r->setAccessible(true);
+        self::assertSame($expected, $r->getValue($object));
+    }
+
+    private function assertAttributeEquals($expected, $attribute, $object)
+    {
+        $r = new ReflectionProperty($object, $attribute);
+        $r->setAccessible(true);
+        self::assertEquals($expected, $r->getValue($object));
     }
 }


### PR DESCRIPTION
Q | A
-- | --
New Feature | yes

Summary
To be prepared for the december release of PHP 8.0, this repository has some additional TODOs to be tested against the new major version.

In order to make this repository compatible, one has to follow these steps:

- [x] Modify composer.json to provide support for PHP 8.0 by adding the constraint ~8.0.0
- [x] Modify composer.json to drop support for PHP less than 7.3
- [x] Modify composer.json to implement phpunit 9.3 which supports PHP 7.3+
- [x] Modify .travis.yml to ignore platform requirements when installing composer dependencies (simply add --ignore-platform-reqs to COMPOSER_ARGS env variable)
- [x] Modify .travis.yml to add PHP 8.0 to the matrix (NOTE: Do not allow failures as PHP 8.0 has a feature freeze since 2020-08-04!)
- [x] Modify source code in case there are incompatibilities with PHP 8.0

closes #4