### PR TITLE
Add reuse_query_params to UrlHelper to allow reuse of existing request query params

### DIFF
--- a/src/UrlHelperMiddleware.php
+++ b/src/UrlHelperMiddleware.php
@@ -32,11 +32,15 @@ class UrlHelperMiddleware implements MiddlewareInterface
     }
 
     /**
+     * Inject the helper with the request instance.
+     *
      * Inject the UrlHelper instance with a RouteResult, if present as a request attribute.
      * Injects the helper, and then dispatches the next middleware.
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
+        $this->helper->setRequest($request);
+
         $result = $request->getAttribute(RouteResult::class, false);
 
         if ($result instanceof RouteResult) {

--- a/test/UrlHelperMiddlewareTest.php
+++ b/test/UrlHelperMiddlewareTest.php
@@ -33,11 +33,6 @@ class UrlHelperMiddlewareTest extends TestCase
     public function setUp(): void
     {
         $this->helper = $this->prophesize(UrlHelper::class);
-
-        $request = $this->prophesize(ServerRequestInterface::class);
-        $request->getQueryparams()->willReturn([]);
-
-        $this->helper->setRequest($request->reveal());
     }
 
     public function createMiddleware()
@@ -53,6 +48,7 @@ class UrlHelperMiddlewareTest extends TestCase
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getAttribute(RouteResult::class, false)->willReturn($routeResult);
         $this->helper->setRouteResult($routeResult)->shouldBeCalled();
+        $this->helper->setRequest($request)->shouldBeCalled();
 
         $handler = $this->prophesize(RequestHandlerInterface::class);
         $handler->handle(Argument::type(ServerRequestInterface::class))->will([$response, 'reveal']);
@@ -70,6 +66,7 @@ class UrlHelperMiddlewareTest extends TestCase
 
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getAttribute(RouteResult::class, false)->willReturn(false);
+        $this->helper->setRequest($request)->shouldBeCalled();
         $this->helper->setRouteResult(Argument::any())->shouldNotBeCalled();
 
         $handler = $this->prophesize(RequestHandlerInterface::class);

--- a/test/UrlHelperMiddlewareTest.php
+++ b/test/UrlHelperMiddlewareTest.php
@@ -33,6 +33,11 @@ class UrlHelperMiddlewareTest extends TestCase
     public function setUp(): void
     {
         $this->helper = $this->prophesize(UrlHelper::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getQueryparams()->willReturn([]);
+
+        $this->helper->setRequest($request->reveal());
     }
 
     public function createMiddleware()

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -21,6 +21,7 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Http\Message\ServerRequestInterface;
 use ReflectionProperty;
 use stdClass;
 use TypeError;
@@ -43,7 +44,12 @@ class UrlHelperTest extends TestCase
 
     public function createHelper()
     {
-        return new UrlHelper($this->router->reveal());
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getQueryParams()->willReturn([]);
+
+        $helper = new UrlHelper($this->router->reveal());
+        $helper->setRequest($request->reveal());
+        return $helper;
     }
 
     public function testRaisesExceptionOnInvocationIfNoRouteProvidedAndNoResultPresent()

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -238,7 +238,7 @@ class UrlHelperTest extends TestCase
         $fragmentIdentifier = 'foobar';
         $options = ['router' => ['foobar' => 'baz'], 'reuse_result_params' => false];
 
-        $helper = Mockery::mock(UrlHelper::class)->shouldDeferMissing();
+        $helper = Mockery::mock(UrlHelper::class)->makePartial();
         $helper->shouldReceive('__invoke')
             ->once()
             ->with($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options)


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

It's currently possible to reuse route parameters (by default), however it is not possible to reuse existing query parameters when generating routes.

For example if the existing url is "/?filter=name" and you use the UrlHelper class to regenerate the route with using: `$this-url('home', [], ['page' => 2]);`then the generated URL would be "/?page=2" removing existing parameters. This PR changes that so the generated route would automatically be "/?filter=name&page=2" by using existing parameters.

Any parameters generated via UrlHelper will override existing parameters.

This feature adds the ability to reuse existing request query parameters (enabled by default) when generating a URL for the same route. Similar to the way reusing route parameters can be disabled, this adds the functionality to disable reuse of query parameters using 'reuse_query_params' option in a similar way.

This works by injecting the ServerRequestInterface instance into the UrlHelper via the UrlHelperMiddleware and is enabled by fault.

The existing tests have been updating to support the ServerRequestInterface injection.
