### PR TITLE
Psalm Integration & Laminas Coding Standard 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,9 @@
         "malukenho/docheader": "^0.1.8",
         "mockery/mockery": "^1.4.2",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^9.4.2"
+        "phpunit/phpunit": "^9.4.2",
+        "psalm/plugin-phpunit": "^0.15.1",
+        "vimeo/psalm": "^4.7"
     },
     "autoload": {
         "psr-4": {
@@ -63,6 +65,7 @@
         "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "test": "phpunit --colors=always",
+        "static-analysis": "psalm --shepherd --stats",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
         "license-check": "docheader check src/ test/"
     },

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
+        "laminas/laminas-coding-standard": "~2.1.0",
         "laminas/laminas-diactoros": "^1.7.1",
         "malukenho/docheader": "^0.1.8",
         "mockery/mockery": "^1.4.2",

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     },
     "require": {
         "php": "^7.3 || ~8.0.0",
+        "ext-json": "*",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-router": "^3.0",
         "psr/container": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     },
     "require": {
         "php": "^7.3 || ~8.0.0",
-        "ext-json": "*",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-router": "^3.0",
         "psr/container": "^1.0",
@@ -37,6 +36,7 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
+        "ext-json": "*",
         "laminas/laminas-coding-standard": "~2.1.0",
         "laminas/laminas-diactoros": "^1.7.1",
         "malukenho/docheader": "^0.1.8",
@@ -45,6 +45,9 @@
         "phpunit/phpunit": "^9.4.2",
         "psalm/plugin-phpunit": "^0.15.1",
         "vimeo/psalm": "^4.7"
+    },
+    "suggest": {
+        "ext-json": "If you wish to use the JsonStrategy with BodyParamsMiddleware"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e5b2691dae71d885295e9017cb39b58c",
+    "content-hash": "9ccbd3ce45aeddafaf75de40dc9fe937",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -4800,9 +4800,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "^7.3 || ~8.0.0"
+    },
+    "platform-dev": {
         "ext-json": "*"
     },
-    "platform-dev": [],
     "plugin-api-version": "2.0.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca4549365e30e59f678420844e548c37",
+    "content-hash": "e5b2691dae71d885295e9017cb39b58c",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -422,6 +422,390 @@
     ],
     "packages-dev": [
         {
+            "name": "amphp/amp",
+            "version": "v2.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/efca2b32a7580087adb8aabbff6be1dc1bb924a9",
+                "reference": "efca2b32a7580087adb8aabbff6be1dc1bb924a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1",
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6.0.9 | ^7",
+                "psalm/phar": "^3.11@dev",
+                "react/promise": "^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php",
+                    "lib/Internal/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                },
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "http://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/v2.5.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-01-10T17:06:37+00:00"
+        },
+        {
+            "name": "amphp/byte-stream",
+            "version": "v1.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/byte-stream.git",
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/acbd8002b3536485c997c4e019206b3f10ca15bd",
+                "reference": "acbd8002b3536485c997c4e019206b3f10ca15bd",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "amphp/phpunit-util": "^1.4",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^6 || ^7 || ^8",
+                "psalm/phar": "^3.11.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Amp\\ByteStream\\": "lib"
+                },
+                "files": [
+                    "lib/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A stream abstraction to make working with non-blocking I/O simple.",
+            "homepage": "http://amphp.org/byte-stream",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "non-blocking",
+                "stream"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/amphp",
+                "issues": "https://github.com/amphp/byte-stream/issues",
+                "source": "https://github.com/amphp/byte-stream/tree/v1.8.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-30T17:13:30+00:00"
+        },
+        {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.11.99.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "7413f0b55a051e89485c5cb9f765fe24bb02a7b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/7413f0b55a051e89485c5cb9f765fe24bb02a7b6",
+                "reference": "7413f0b55a051e89485c5cb9f765fe24bb02a7b6",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7 || ^8"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.11.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/composer/package-versions-deprecated/issues",
+                "source": "https://github.com/composer/package-versions-deprecated/tree/1.11.99.1"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-11T10:22:58+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
+                "reference": "a02fdf930a3c1c3ed3a49b5f63859c0c20e10464",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.54",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.2.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T08:59:24+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "1.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "f27e06cd9675801df441b3656569b328e04aa37c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f27e06cd9675801df441b3656569b328e04aa37c",
+                "reference": "f27e06cd9675801df441b3656569b328e04aa37c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/1.4.6"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-03-25T17:01:18+00:00"
+        },
+        {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.7.1",
             "source": {
@@ -492,6 +876,43 @@
             "time": "2020-12-07T18:04:37+00:00"
         },
         {
+            "name": "dnoegel/php-xdg-base-dir",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dnoegel/php-xdg-base-dir.git",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dnoegel/php-xdg-base-dir/zipball/8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "reference": "8f8a6e48c5ecb0f991c2fdcf5f154a47d85f9ffd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~7.0|~6.0|~5.0|~4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "XdgBaseDir\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "implementation of xdg base directory specification for php",
+            "support": {
+                "issues": "https://github.com/dnoegel/php-xdg-base-dir/issues",
+                "source": "https://github.com/dnoegel/php-xdg-base-dir/tree/v0.1.1"
+            },
+            "time": "2019-12-04T15:06:13+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.4.0",
             "source": {
@@ -559,6 +980,107 @@
                 }
             ],
             "time": "2020-11-10T18:47:58+00:00"
+        },
+        {
+            "name": "felixfbecker/advanced-json-rpc",
+            "version": "v3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
+                "reference": "06f0b06043c7438959dbdeed8bb3f699a19be22e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/06f0b06043c7438959dbdeed8bb3f699a19be22e",
+                "reference": "06f0b06043c7438959dbdeed8bb3f699a19be22e",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^1.0 || ^2.0",
+                "php": "^7.1 || ^8.0",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
+                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.0"
+            },
+            "time": "2021-01-10T17:48:47+00:00"
+        },
+        {
+            "name": "felixfbecker/language-server-protocol",
+            "version": "1.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
+                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
+                "reference": "9d846d1f5cf101deee7a61c8ba7caa0a975cd730",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "*",
+                "squizlabs/php_codesniffer": "^3.1",
+                "vimeo/psalm": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "LanguageServerProtocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                }
+            ],
+            "description": "PHP classes for the Language Server Protocol",
+            "keywords": [
+                "language",
+                "microsoft",
+                "php",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/1.5.1"
+            },
+            "time": "2021-02-22T14:02:09+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -935,6 +1457,57 @@
             "time": "2020-11-13T09:40:50+00:00"
         },
         {
+            "name": "netresearch/jsonmapper",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweiske/jsonmapper.git",
+                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/e0f1e33a71587aca81be5cffbb9746510e1fe04e",
+                "reference": "e0f1e33a71587aca81be5cffbb9746510e1fe04e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.35 || ~5.7 || ~6.4 || ~7.0",
+                "squizlabs/php_codesniffer": "~3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonMapper": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "OSL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Weiske",
+                    "email": "cweiske@cweiske.de",
+                    "homepage": "http://github.com/cweiske/jsonmapper/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Map nested JSON structures onto PHP classes",
+            "support": {
+                "email": "cweiske@cweiske.de",
+                "issues": "https://github.com/cweiske/jsonmapper/issues",
+                "source": "https://github.com/cweiske/jsonmapper/tree/master"
+            },
+            "time": "2020-04-16T18:48:43+00:00"
+        },
+        {
             "name": "nikic/php-parser",
             "version": "v4.10.4",
             "source": {
@@ -989,6 +1562,59 @@
                 "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.4"
             },
             "time": "2020-12-20T10:01:03+00:00"
+        },
+        {
+            "name": "openlss/lib-array2xml",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nullivex/lib-array2xml.git",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nullivex/lib-array2xml/zipball/a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "reference": "a91f18a8dfc69ffabe5f9b068bc39bb202c81d90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "LSS": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Tong",
+                    "email": "bryan@nullivex.com",
+                    "homepage": "https://www.nullivex.com"
+                },
+                {
+                    "name": "Tony Butler",
+                    "email": "spudz76@gmail.com",
+                    "homepage": "https://www.nullivex.com"
+                }
+            ],
+            "description": "Array2XML conversion library credit to lalit.org",
+            "homepage": "https://www.nullivex.com",
+            "keywords": [
+                "array",
+                "array conversion",
+                "xml",
+                "xml conversion"
+            ],
+            "support": {
+                "issues": "https://github.com/nullivex/lib-array2xml/issues",
+                "source": "https://github.com/nullivex/lib-array2xml/tree/master"
+            },
+            "time": "2019-03-29T20:06:56+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1851,6 +2477,116 @@
                 }
             ],
             "time": "2021-03-23T07:16:29+00:00"
+        },
+        {
+            "name": "psalm/plugin-phpunit",
+            "version": "0.15.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
+                "reference": "30ca25ce069bf4943c36e59b7df6954f6af05e64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/30ca25ce069bf4943c36e59b7df6954f6af05e64",
+                "reference": "30ca25ce069bf4943c36e59b7df6954f6af05e64",
+                "shasum": ""
+            },
+            "require": {
+                "composer/package-versions-deprecated": "^1.10",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "ext-simplexml": "*",
+                "php": "^7.1 || ^8.0",
+                "vimeo/psalm": "dev-master || dev-4.x || ^4.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.5"
+            },
+            "require-dev": {
+                "codeception/codeception": "^4.0.3",
+                "php": "^7.3 || ^8.0",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.3.1",
+                "weirdan/codeception-psalm-module": "^0.11.0",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "type": "psalm-plugin",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Psalm\\PhpUnitPlugin\\Plugin"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\PhpUnitPlugin\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Brown",
+                    "email": "github@muglug.com"
+                }
+            ],
+            "description": "Psalm plugin for PHPUnit",
+            "support": {
+                "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.15.1"
+            },
+            "time": "2021-01-23T00:19:07+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.3"
+            },
+            "time": "2020-03-23T09:12:05+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -3790,6 +4526,111 @@
             "time": "2020-07-12T23:59:07+00:00"
         },
         {
+            "name": "vimeo/psalm",
+            "version": "4.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vimeo/psalm.git",
+                "reference": "d4377c0baf3ffbf0b1ec6998e8d1be2a40971005"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/d4377c0baf3ffbf0b1ec6998e8d1be2a40971005",
+                "reference": "d4377c0baf3ffbf0b1ec6998e8d1be2a40971005",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^2.4.2",
+                "amphp/byte-stream": "^1.5",
+                "composer/package-versions-deprecated": "^1.8.0",
+                "composer/semver": "^1.4 || ^2.0 || ^3.0",
+                "composer/xdebug-handler": "^1.1",
+                "dnoegel/php-xdg-base-dir": "^0.1.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "felixfbecker/advanced-json-rpc": "^3.0.3",
+                "felixfbecker/language-server-protocol": "^1.5",
+                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "nikic/php-parser": "^4.10.1",
+                "openlss/lib-array2xml": "^1.0",
+                "php": "^7.1|^8",
+                "sebastian/diff": "^3.0 || ^4.0",
+                "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
+                "webmozart/path-util": "^2.3"
+            },
+            "provide": {
+                "psalm/psalm": "self.version"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.2",
+                "brianium/paratest": "^4.0||^6.0",
+                "ext-curl": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpdocumentor/reflection-docblock": "^5",
+                "phpmyadmin/sql-parser": "5.1.0||dev-master",
+                "phpspec/prophecy": ">=1.9.0",
+                "phpunit/phpunit": "^9.0",
+                "psalm/plugin-phpunit": "^0.13",
+                "slevomat/coding-standard": "^6.3.11",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.3",
+                "weirdan/phpunit-appveyor-reporter": "^1.0.0",
+                "weirdan/prophecy-shim": "^1.0 || ^2.0"
+            },
+            "suggest": {
+                "ext-igbinary": "^2.0.5"
+            },
+            "bin": [
+                "psalm",
+                "psalm-language-server",
+                "psalm-plugin",
+                "psalm-refactor",
+                "psalter"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psalm\\": "src/Psalm/"
+                },
+                "files": [
+                    "src/functions.php",
+                    "src/spl_object_id.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Brown"
+                }
+            ],
+            "description": "A static analysis tool for finding errors in PHP applications",
+            "keywords": [
+                "code",
+                "inspection",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/vimeo/psalm/issues",
+                "source": "https://github.com/vimeo/psalm/tree/4.7.0"
+            },
+            "time": "2021-03-29T03:54:38+00:00"
+        },
+        {
             "name": "webimpress/coding-standard",
             "version": "1.2.2",
             "source": {
@@ -3901,6 +4742,56 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.10.0"
             },
             "time": "2021-03-09T10:59:23+00:00"
+        },
+        {
+            "name": "webmozart/path-util",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/path-util.git",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/path-util/zipball/d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "reference": "d939f7edc24c9a1bb9c0dee5cb05d8e859490725",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "webmozart/assert": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\PathUtil\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "support": {
+                "issues": "https://github.com/webmozart/path-util/issues",
+                "source": "https://github.com/webmozart/path-util/tree/2.3.0"
+            },
+            "time": "2015-12-17T08:42:14+00:00"
         }
     ],
     "aliases": [],
@@ -3909,7 +4800,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0"
+        "php": "^7.3 || ~8.0.0",
+        "ext-json": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e53bb3aa8b65213d43f22ce02a087974",
+    "content-hash": "ca4549365e30e59f678420844e548c37",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -422,6 +422,76 @@
     ],
     "packages-dev": [
         {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.4.0",
             "source": {
@@ -543,31 +613,37 @@
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "1.0.0",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539"
+                "reference": "d75f1acf615232e108da2d2cf5a7df3e527b8f38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/08880ce2fbfe62d471cd3cb766a91da630b32539",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/d75f1acf615232e108da2d2cf5a7df3e527b8f38",
+                "reference": "d75f1acf615232e108da2d2cf5a7df3e527b8f38",
                 "shasum": ""
             },
             "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
                 "laminas/laminas-zendframework-bridge": "^1.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "php": "^7.3 || ~8.0.0",
+                "slevomat/coding-standard": "^6.4.1",
+                "squizlabs/php_codesniffer": "^3.5.8",
+                "webimpress/coding-standard": "^1.1.6"
             },
-            "replace": {
-                "zendframework/zend-coding-standard": "self.version"
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
+                }
             },
-            "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Laminas coding standard",
+            "description": "Laminas Coding Standard",
             "homepage": "https://laminas.dev",
             "keywords": [
                 "Coding Standard",
@@ -581,7 +657,13 @@
                 "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
                 "source": "https://github.com/laminas/laminas-coding-standard"
             },
-            "time": "2019-12-31T16:28:26+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-10-26T07:33:05+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",
@@ -1295,6 +1377,59 @@
                 "source": "https://github.com/phpspec/prophecy-phpunit/tree/v2.0.1"
             },
             "time": "2020-07-09T08:33:42+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "0.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.5",
+                "ergebnis/composer-normalize": "^2.0.2",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "phing/phing": "^2.16.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.26",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^6.3",
+                "slevomat/coding-standard": "^4.7.2",
+                "symfony/process": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/master"
+            },
+            "time": "2020-08-03T20:32:43+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2682,64 +2817,98 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.9.2",
+            "name": "slevomat/coding-standard",
+            "version": "6.4.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/696dcca217d0c9da2c40d02731526c1e25b65346",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpdoc-parser": "0.4.5 - 0.4.9",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "phing/phing": "2.16.3",
+                "php-parallel-lint/php-parallel-lint": "1.2.0",
+                "phpstan/phpstan": "0.12.48",
+                "phpstan/phpstan-deprecation-rules": "0.12.5",
+                "phpstan/phpstan-phpunit": "0.12.16",
+                "phpstan/phpstan-strict-rules": "0.12.5",
+                "phpunit/phpunit": "7.5.20|8.5.5|9.4.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/6.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-05T12:39:37+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2752,7 +2921,7 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
@@ -2762,7 +2931,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2018-11-07T22:31:41+00:00"
+            "time": "2021-04-09T00:54:41+00:00"
         },
         {
             "name": "symfony/console",
@@ -3619,6 +3788,61 @@
                 }
             ],
             "time": "2020-07-12T23:59:07+00:00"
+        },
+        {
+            "name": "webimpress/coding-standard",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "8f4a220de33f471a8101836f7ec72b852c3f9f03"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/8f4a220de33f471a8101836f7ec72b852c3f9f03",
+                "reference": "8f4a220de33f471a8101836f7ec72b852c3f9f03",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.2.x-dev",
+                "dev-develop": "1.3.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-04-12T12:51:27+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="Laminas coding standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
+    <rule ref="./vendor/laminas/laminas-coding-standard/src/LaminasCodingStandard/ruleset.xml"/>
 
     <!-- Paths to check -->
     <file>src</file>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="Laminas coding standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/src/LaminasCodingStandard/ruleset.xml"/>
+    <rule ref="LaminasCodingStandard" />
 
     <!-- Paths to check -->
     <file>src</file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,548 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.7.0@d4377c0baf3ffbf0b1ec6998e8d1be2a40971005">
+  <file src="src/BodyParams/JsonStrategy.php">
+    <MixedAssignment occurrences="1">
+      <code>$parsedBody</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/ServerUrlHelper.php">
+    <MissingConstructor occurrences="1">
+      <code>$uri</code>
+    </MissingConstructor>
+    <RedundantCast occurrences="1">
+      <code>(string) $specification</code>
+    </RedundantCast>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$this-&gt;uri instanceof UriInterface</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
+  <file src="src/ServerUrlMiddlewareFactory.php">
+    <MixedArgument occurrences="1"/>
+  </file>
+  <file src="src/Template/RouteTemplateVariableMiddleware.php">
+    <MixedAssignment occurrences="2">
+      <code>$container</code>
+      <code>$routeResult</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="2">
+      <code>with</code>
+      <code>with</code>
+    </MixedMethodCall>
+  </file>
+  <file src="src/Template/TemplateVariableContainer.php">
+    <MixedPropertyTypeCoercion occurrences="1">
+      <code>array_merge($this-&gt;variables, $values)</code>
+    </MixedPropertyTypeCoercion>
+  </file>
+  <file src="src/Template/TemplateVariableContainerMiddleware.php">
+    <MixedAssignment occurrences="1">
+      <code>$container</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/UrlHelper.php">
+    <MixedArgument occurrences="2">
+      <code>$routerOptions</code>
+      <code>$routerOptions</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$routerOptions</code>
+    </MixedAssignment>
+    <PossiblyFalseArgument occurrences="1">
+      <code>$name</code>
+    </PossiblyFalseArgument>
+    <PossiblyNullReference occurrences="1">
+      <code>getQueryParams</code>
+    </PossiblyNullReference>
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>$request</code>
+      <code>$result</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="src/UrlHelperFactory.php">
+    <MixedArgument occurrences="3">
+      <code>$container-&gt;get($this-&gt;routerServiceName)</code>
+      <code>$data['basePath'] ?? '/'</code>
+      <code>$data['routerServiceName'] ?? RouterInterface::class</code>
+    </MixedArgument>
+  </file>
+  <file src="src/UrlHelperMiddleware.php">
+    <MixedAssignment occurrences="1">
+      <code>$result</code>
+    </MixedAssignment>
+  </file>
+  <file src="src/UrlHelperMiddlewareFactory.php">
+    <MixedArgument occurrences="2">
+      <code>$container-&gt;get($this-&gt;urlHelperServiceName)</code>
+      <code>$data['urlHelperServiceName'] ?? UrlHelper::class</code>
+    </MixedArgument>
+  </file>
+  <file src="test/AttributeAssertionsTrait.php">
+    <MixedArgument occurrences="1">
+      <code>$r-&gt;getValue($object)</code>
+    </MixedArgument>
+  </file>
+  <file src="test/BodyParams/BodyParamsMiddlewareTest.php">
+    <MissingClosureParamType occurrences="1">
+      <code>$args</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="1">
+      <code>function ($args) use ($callback) {</code>
+    </MissingClosureReturnType>
+    <MixedArgument occurrences="6">
+      <code>$this-&gt;mockHandlerToNeverTrigger()-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedArrayAccess occurrences="1">
+      <code>$args[0]</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="1">
+      <code>$request</code>
+    </MixedAssignment>
+    <PossiblyUndefinedMethod occurrences="6">
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="test/ConfigProviderTest.php">
+    <RedundantCondition occurrences="1">
+      <code>assertIsArray</code>
+    </RedundantCondition>
+  </file>
+  <file src="test/ContentLengthMiddlewareTest.php">
+    <MixedAssignment occurrences="3">
+      <code>$response</code>
+      <code>$response</code>
+      <code>$response</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="22">
+      <code>getBody</code>
+      <code>getBody</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>hasHeader</code>
+      <code>hasHeader</code>
+      <code>hasHeader</code>
+      <code>process</code>
+      <code>process</code>
+      <code>process</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>withHeader</code>
+    </MixedMethodCall>
+    <UndefinedThisPropertyAssignment occurrences="5">
+      <code>$this-&gt;handler</code>
+      <code>$this-&gt;middleware</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;response</code>
+      <code>$this-&gt;stream</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="14">
+      <code>$this-&gt;handler</code>
+      <code>$this-&gt;handler</code>
+      <code>$this-&gt;handler</code>
+      <code>$this-&gt;middleware</code>
+      <code>$this-&gt;middleware</code>
+      <code>$this-&gt;middleware</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;response</code>
+      <code>$this-&gt;response</code>
+      <code>$this-&gt;response</code>
+      <code>$this-&gt;stream</code>
+      <code>$this-&gt;stream</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/ExceptionTest.php">
+    <InvalidLiteralArgument occurrences="1">
+      <code>ExceptionInterface::class</code>
+    </InvalidLiteralArgument>
+    <MixedInferredReturnType occurrences="1">
+      <code>Generator</code>
+    </MixedInferredReturnType>
+    <PossiblyFalseOperand occurrences="1">
+      <code>strrpos(ExceptionInterface::class, '\\')</code>
+    </PossiblyFalseOperand>
+  </file>
+  <file src="test/ServerUrlHelperTest.php">
+    <DeprecatedMethod occurrences="1">
+      <code>shouldDeferMissing</code>
+    </DeprecatedMethod>
+    <ImplicitToStringCast occurrences="1">
+      <code>array&lt;string, Uri|string[]&gt;</code>
+    </ImplicitToStringCast>
+    <InvalidReturnStatement occurrences="5"/>
+    <InvalidReturnType occurrences="6">
+      <code>array&lt;string, Uri|string[]&gt;</code>
+      <code>array&lt;string, Uri|string|null[]&gt;</code>
+      <code>array&lt;string, Uri|string|null[]&gt;</code>
+      <code>array&lt;string, Uri|string|null[]&gt;</code>
+      <code>array&lt;string, Uri|string|null[]&gt;</code>
+      <code>array&lt;string, string|null[]&gt;</code>
+    </InvalidReturnType>
+    <MixedMethodCall occurrences="2">
+      <code>andReturn</code>
+      <code>with</code>
+    </MixedMethodCall>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>once</code>
+    </PossiblyUndefinedMethod>
+    <RedundantCast occurrences="1">
+      <code>(string) $expected</code>
+    </RedundantCast>
+    <UndefinedMagicMethod occurrences="1">
+      <code>once</code>
+    </UndefinedMagicMethod>
+  </file>
+  <file src="test/ServerUrlMiddlewareTest.php">
+    <MissingClosureParamType occurrences="1">
+      <code>$req</code>
+    </MissingClosureParamType>
+    <UnusedClosureParam occurrences="1">
+      <code>$req</code>
+    </UnusedClosureParam>
+    <UnusedVariable occurrences="1">
+      <code>$test</code>
+    </UnusedVariable>
+  </file>
+  <file src="test/Template/RouteTemplateVariableMiddlewareTest.php">
+    <InvalidArgument occurrences="2"/>
+    <MissingClosureParamType occurrences="7">
+      <code>$args</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+    </MissingClosureParamType>
+    <MissingClosureReturnType occurrences="5">
+      <code>function ($args) {</code>
+      <code>function ($container) use ($originalContainer) {</code>
+      <code>function ($container) use ($originalContainer) {</code>
+      <code>function ($container) use ($originalContainer, $routeResult) {</code>
+      <code>function ($container) use ($originalContainer, $routeResult) {</code>
+    </MissingClosureReturnType>
+    <MixedArgumentTypeCoercion occurrences="4"/>
+    <MixedArrayAccess occurrences="1">
+      <code>$args[1]</code>
+    </MixedArrayAccess>
+    <MixedAssignment occurrences="2">
+      <code>$originalContainer</code>
+      <code>$originalContainer</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="62">
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getAttribute</code>
+      <code>getAttribute</code>
+      <code>getAttribute</code>
+      <code>getAttribute</code>
+      <code>getAttribute</code>
+      <code>getAttribute</code>
+      <code>handle</code>
+      <code>handle</code>
+      <code>handle</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>process</code>
+      <code>process</code>
+      <code>process</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>will</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>withAttribute</code>
+      <code>withAttribute</code>
+      <code>withAttribute</code>
+      <code>withAttribute</code>
+      <code>withAttribute</code>
+      <code>withAttribute</code>
+    </MixedMethodCall>
+    <UndefinedThisPropertyAssignment occurrences="5">
+      <code>$this-&gt;container</code>
+      <code>$this-&gt;handler</code>
+      <code>$this-&gt;middleware</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;response</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="14">
+      <code>$this-&gt;container</code>
+      <code>$this-&gt;container</code>
+      <code>$this-&gt;handler</code>
+      <code>$this-&gt;handler</code>
+      <code>$this-&gt;handler</code>
+      <code>$this-&gt;middleware</code>
+      <code>$this-&gt;middleware</code>
+      <code>$this-&gt;middleware</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;response</code>
+      <code>$this-&gt;response</code>
+      <code>$this-&gt;response</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/Template/TemplateVariableContainerMiddlewareTest.php">
+    <MixedMethodCall occurrences="28">
+      <code>getAttribute</code>
+      <code>getAttribute</code>
+      <code>handle</code>
+      <code>handle</code>
+      <code>process</code>
+      <code>process</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldBeCalledTimes</code>
+      <code>shouldNotBeCalled</code>
+      <code>shouldNotBeCalled</code>
+      <code>will</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>withAttribute</code>
+      <code>withAttribute</code>
+      <code>withAttribute</code>
+      <code>withAttribute</code>
+    </MixedMethodCall>
+    <UndefinedThisPropertyAssignment occurrences="4">
+      <code>$this-&gt;handler</code>
+      <code>$this-&gt;middleware</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;response</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="8">
+      <code>$this-&gt;handler</code>
+      <code>$this-&gt;handler</code>
+      <code>$this-&gt;middleware</code>
+      <code>$this-&gt;middleware</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;request</code>
+      <code>$this-&gt;response</code>
+      <code>$this-&gt;response</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/Template/TemplateVariableContainerTest.php">
+    <MixedArgument occurrences="2">
+      <code>$container</code>
+      <code>$this-&gt;container</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="3">
+      <code>$container</code>
+      <code>$container</code>
+      <code>$container</code>
+    </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>TemplateVariableContainer</code>
+    </MixedInferredReturnType>
+    <MixedMethodCall occurrences="12">
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>has</code>
+      <code>merge</code>
+      <code>merge</code>
+      <code>mergeForTemplate</code>
+      <code>with</code>
+    </MixedMethodCall>
+    <MixedReturnStatement occurrences="1">
+      <code>$container</code>
+    </MixedReturnStatement>
+    <UndefinedThisPropertyAssignment occurrences="1">
+      <code>$this-&gt;container</code>
+    </UndefinedThisPropertyAssignment>
+    <UndefinedThisPropertyFetch occurrences="6">
+      <code>$this-&gt;container</code>
+      <code>$this-&gt;container</code>
+      <code>$this-&gt;container</code>
+      <code>$this-&gt;container</code>
+      <code>$this-&gt;container</code>
+      <code>$this-&gt;container</code>
+    </UndefinedThisPropertyFetch>
+  </file>
+  <file src="test/UrlHelperFactoryTest.php">
+    <MixedArgument occurrences="7">
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;router-&gt;reveal()</code>
+      <code>$this-&gt;router-&gt;reveal()</code>
+      <code>Router::class</code>
+      <code>Router::class</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="1">
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="1">
+      <code>willReturn</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="7">
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedClass occurrences="4">
+      <code>Router</code>
+      <code>Router</code>
+      <code>Router</code>
+      <code>Router</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/UrlHelperMiddlewareFactoryTest.php">
+    <MixedArgument occurrences="5">
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>$this-&gt;container-&gt;reveal()</code>
+      <code>MyUrlHelper::class</code>
+      <code>MyUrlHelper::class</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="1">
+      <code>$service</code>
+    </MixedAssignment>
+    <MixedMethodCall occurrences="1">
+      <code>willReturn</code>
+    </MixedMethodCall>
+    <PossiblyInvalidMethodCall occurrences="3">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="3">
+      <code>reveal</code>
+      <code>reveal</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedClass occurrences="4">
+      <code>MyUrlHelper</code>
+      <code>MyUrlHelper</code>
+      <code>MyUrlHelper</code>
+      <code>MyUrlHelper</code>
+    </UndefinedClass>
+  </file>
+  <file src="test/UrlHelperMiddlewareTest.php">
+    <InvalidArgument occurrences="3">
+      <code>$request</code>
+      <code>$request</code>
+      <code>Argument::any()</code>
+    </InvalidArgument>
+    <MixedArgument occurrences="1">
+      <code>$this-&gt;helper-&gt;reveal()</code>
+    </MixedArgument>
+    <PossiblyNullReference occurrences="4">
+      <code>shouldBeCalled</code>
+      <code>shouldBeCalled</code>
+      <code>shouldBeCalled</code>
+      <code>shouldNotBeCalled</code>
+    </PossiblyNullReference>
+    <PossiblyUndefinedMethod occurrences="1">
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+  </file>
+  <file src="test/UrlHelperTest.php">
+    <MixedArgument occurrences="2">
+      <code>$basePath</code>
+      <code>$this-&gt;router-&gt;reveal()</code>
+    </MixedArgument>
+    <MixedMethodCall occurrences="2">
+      <code>andReturn</code>
+      <code>with</code>
+    </MixedMethodCall>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>testQueryParametersAndFragment</code>
+    </PossiblyInvalidArgument>
+    <PossiblyInvalidMethodCall occurrences="20">
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willThrow</code>
+    </PossiblyInvalidMethodCall>
+    <PossiblyUndefinedMethod occurrences="2">
+      <code>once</code>
+      <code>reveal</code>
+    </PossiblyUndefinedMethod>
+    <UndefinedMagicMethod occurrences="1">
+      <code>once</code>
+    </UndefinedMagicMethod>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<psalm
+        totallyTyped="true"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://getpsalm.org/schema/config"
+        xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
+>
+    <projectFiles>
+        <directory name="src"/>
+        <directory name="test"/>
+        <ignoreFiles>
+            <directory name="vendor"/>
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <InternalMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
+            </errorLevel>
+            <errorLevel type="suppress">
+                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
+            </errorLevel>
+        </InternalMethod>
+    </issueHandlers>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+</psalm>

--- a/src/BodyParams/BodyParamsMiddleware.php
+++ b/src/BodyParams/BodyParamsMiddleware.php
@@ -19,9 +19,7 @@ use function in_array;
 
 class BodyParamsMiddleware implements MiddlewareInterface
 {
-    /**
-     * @var StrategyInterface[]
-     */
+    /** @var StrategyInterface[] */
     private $strategies = [];
 
     /**
@@ -52,7 +50,7 @@ class BodyParamsMiddleware implements MiddlewareInterface
     /**
      * Add a body parsing strategy to the middleware.
      */
-    public function addStrategy(StrategyInterface $strategy) : void
+    public function addStrategy(StrategyInterface $strategy): void
     {
         $this->strategies[] = $strategy;
     }
@@ -60,7 +58,7 @@ class BodyParamsMiddleware implements MiddlewareInterface
     /**
      * Clear all strategies from the middleware.
      */
-    public function clearStrategies() : void
+    public function clearStrategies(): void
     {
         $this->strategies = [];
     }
@@ -69,7 +67,7 @@ class BodyParamsMiddleware implements MiddlewareInterface
      * Process an incoming server request and return a response, optionally delegating
      * to the next middleware component to create the response.
      */
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if (in_array($request->getMethod(), $this->nonBodyRequests)) {
             return $handler->handle($request);

--- a/src/BodyParams/FormUrlEncodedStrategy.php
+++ b/src/BodyParams/FormUrlEncodedStrategy.php
@@ -17,12 +17,12 @@ use function preg_match;
 
 class FormUrlEncodedStrategy implements StrategyInterface
 {
-    public function match(string $contentType) : bool
+    public function match(string $contentType): bool
     {
         return 1 === preg_match('#^application/x-www-form-urlencoded($|[ ;])#', $contentType);
     }
 
-    public function parse(ServerRequestInterface $request) : ServerRequestInterface
+    public function parse(ServerRequestInterface $request): ServerRequestInterface
     {
         $parsedBody = $request->getParsedBody();
 

--- a/src/BodyParams/JsonStrategy.php
+++ b/src/BodyParams/JsonStrategy.php
@@ -13,6 +13,7 @@ namespace Mezzio\Helper\BodyParams;
 use Mezzio\Helper\Exception\MalformedRequestBodyException;
 use Psr\Http\Message\ServerRequestInterface;
 
+use function is_array;
 use function json_decode;
 use function json_last_error;
 use function json_last_error_msg;

--- a/src/BodyParams/JsonStrategy.php
+++ b/src/BodyParams/JsonStrategy.php
@@ -13,20 +13,17 @@ namespace Mezzio\Helper\BodyParams;
 use Mezzio\Helper\Exception\MalformedRequestBodyException;
 use Psr\Http\Message\ServerRequestInterface;
 
-use function array_shift;
-use function explode;
 use function json_decode;
 use function json_last_error;
 use function json_last_error_msg;
 use function preg_match;
 use function sprintf;
-use function trim;
 
 use const JSON_ERROR_NONE;
 
 class JsonStrategy implements StrategyInterface
 {
-    public function match(string $contentType) : bool
+    public function match(string $contentType): bool
     {
         return 1 === preg_match('#^application/(|[\S]+\+)json($|[ ;])#', $contentType);
     }
@@ -36,7 +33,7 @@ class JsonStrategy implements StrategyInterface
      *
      * @throws MalformedRequestBodyException
      */
-    public function parse(ServerRequestInterface $request) : ServerRequestInterface
+    public function parse(ServerRequestInterface $request): ServerRequestInterface
     {
         $rawBody = (string) $request->getBody();
 

--- a/src/BodyParams/StrategyInterface.php
+++ b/src/BodyParams/StrategyInterface.php
@@ -22,13 +22,10 @@ interface StrategyInterface
      *
      * @return bool Whether or not the strategy matches.
      */
-    public function match(string $contentType) : bool;
+    public function match(string $contentType): bool;
 
     /**
      * Parse the body content and return a new request.
-     *
-     * @param ServerRequestInterface $request
-     * @return ServerRequestInterface
      */
-    public function parse(ServerRequestInterface $request) : ServerRequestInterface;
+    public function parse(ServerRequestInterface $request): ServerRequestInterface;
 }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -12,14 +12,14 @@ namespace Mezzio\Helper;
 
 class ConfigProvider
 {
-    public function __invoke() : array
+    public function __invoke(): array
     {
         return [
             'dependencies' => $this->getDependencies(),
         ];
     }
 
-    public function getDependencies() : array
+    public function getDependencies(): array
     {
         // @codingStandardsIgnoreStart
         // phpcs:disable

--- a/src/ContentLengthMiddleware.php
+++ b/src/ContentLengthMiddleware.php
@@ -27,14 +27,14 @@ class ContentLengthMiddleware implements MiddlewareInterface
     /**
      * {@inheritDoc}
      */
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $response = $handler->handle($request);
         if ($response->hasHeader('Content-Length')) {
             return $response;
         }
 
-        $body = $response->getBody();
+        $body     = $response->getBody();
         $bodySize = $body->getSize();
         if (null === $bodySize) {
             return $response;

--- a/src/Exception/MalformedRequestBodyException.php
+++ b/src/Exception/MalformedRequestBodyException.php
@@ -10,11 +10,12 @@ declare(strict_types=1);
 
 namespace Mezzio\Helper\Exception;
 
+use Exception;
 use InvalidArgumentException;
 
 class MalformedRequestBodyException extends InvalidArgumentException implements ExceptionInterface
 {
-    public function __construct($message, \Exception $previous = null)
+    public function __construct($message, ?Exception $previous = null)
     {
         parent::__construct($message, 400, $previous);
     }

--- a/src/Exception/MalformedRequestBodyException.php
+++ b/src/Exception/MalformedRequestBodyException.php
@@ -15,8 +15,7 @@ use InvalidArgumentException;
 
 class MalformedRequestBodyException extends InvalidArgumentException implements ExceptionInterface
 {
-    /** @param string $message */
-    public function __construct($message, ?Exception $previous = null)
+    public function __construct(string $message, ?Exception $previous = null)
     {
         parent::__construct($message, 400, $previous);
     }

--- a/src/Exception/MalformedRequestBodyException.php
+++ b/src/Exception/MalformedRequestBodyException.php
@@ -15,7 +15,8 @@ use InvalidArgumentException;
 
 class MalformedRequestBodyException extends InvalidArgumentException implements ExceptionInterface
 {
-    public function __construct(string $message, ?Exception $previous = null)
+    /** @param string $message */
+    public function __construct($message, ?Exception $previous = null)
     {
         parent::__construct($message, 400, $previous);
     }

--- a/src/Exception/MalformedRequestBodyException.php
+++ b/src/Exception/MalformedRequestBodyException.php
@@ -15,6 +15,7 @@ use InvalidArgumentException;
 
 class MalformedRequestBodyException extends InvalidArgumentException implements ExceptionInterface
 {
+    /** @param string $message */
     public function __construct($message, ?Exception $previous = null)
     {
         parent::__construct($message, 400, $previous);

--- a/src/ServerUrlHelper.php
+++ b/src/ServerUrlHelper.php
@@ -20,9 +20,7 @@ use function rtrim;
  */
 class ServerUrlHelper
 {
-    /**
-     * @var UriInterface
-     */
+    /** @var UriInterface */
     private $uri;
 
     /**
@@ -39,9 +37,9 @@ class ServerUrlHelper
      * The $path may optionally contain the query string and/or fragment to
      * use.
      */
-    public function __invoke(string $path = null) : string
+    public function __invoke(?string $path = null): string
     {
-        $path = $path === null ? '' : $path;
+        $path = $path ?? '';
 
         if ($this->uri instanceof UriInterface) {
             return $this->createUrlFromUri($path);
@@ -63,17 +61,17 @@ class ServerUrlHelper
      *
      * Proxies to __invoke().
      */
-    public function generate(string $path = null) : string
+    public function generate(?string $path = null): string
     {
         return $this($path);
     }
 
-    public function setUri(UriInterface $uri) : void
+    public function setUri(UriInterface $uri): void
     {
         $this->uri = $uri;
     }
 
-    private function createUrlFromUri(string $specification) : string
+    private function createUrlFromUri(string $specification): string
     {
         preg_match(
             '%^(?P<path>[^?#]*)(?:(?:\?(?P<query>[^#]*))?(?:\#(?P<fragment>.*))?)$%',
@@ -81,8 +79,8 @@ class ServerUrlHelper
             $matches
         );
         $path     = $matches['path'];
-        $query    = isset($matches['query']) ? $matches['query'] : '';
-        $fragment = isset($matches['fragment']) ? $matches['fragment'] : '';
+        $query    = $matches['query'] ?? '';
+        $fragment = $matches['fragment'] ?? '';
 
         $uri = $this->uri
             ->withQuery('')

--- a/src/ServerUrlMiddleware.php
+++ b/src/ServerUrlMiddleware.php
@@ -17,9 +17,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class ServerUrlMiddleware implements MiddlewareInterface
 {
-    /**
-     * @var ServerUrlHelper
-     */
+    /** @var ServerUrlHelper */
     private $helper;
 
     public function __construct(ServerUrlHelper $helper)
@@ -32,7 +30,7 @@ class ServerUrlMiddleware implements MiddlewareInterface
      * Injects the ServerUrlHelper with the incoming request URI, and then invoke
      * the next middleware.
      */
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $this->helper->setUri($request->getUri());
         return $handler->handle($request);

--- a/src/ServerUrlMiddlewareFactory.php
+++ b/src/ServerUrlMiddlewareFactory.php
@@ -21,10 +21,11 @@ class ServerUrlMiddlewareFactory
      *
      * @throws Exception\MissingHelperException
      */
-    public function __invoke(ContainerInterface $container) : ServerUrlMiddleware
+    public function __invoke(ContainerInterface $container): ServerUrlMiddleware
     {
-        if (! $container->has(ServerUrlHelper::class)
-            && ! $container->has(\Zend\Expressive\Helper\ServerUrlHelper::class)
+        if (
+            ! $container->has(ServerUrlHelper::class)
+            && ! $container->has(\zend\expressive\helper\serverurlhelper::class)
         ) {
             throw new Exception\MissingHelperException(sprintf(
                 '%s requires a %s service at instantiation; none found',
@@ -36,7 +37,7 @@ class ServerUrlMiddlewareFactory
         return new ServerUrlMiddleware(
             $container->has(ServerUrlHelper::class)
                 ? $container->get(ServerUrlHelper::class)
-                : $container->get(\Zend\Expressive\Helper\ServerUrlHelper::class)
+                : $container->get(\zend\expressive\helper\serverurlhelper::class)
         );
     }
 }

--- a/src/ServerUrlMiddlewareFactory.php
+++ b/src/ServerUrlMiddlewareFactory.php
@@ -25,7 +25,7 @@ class ServerUrlMiddlewareFactory
     {
         if (
             ! $container->has(ServerUrlHelper::class)
-            && ! $container->has(\zend\expressive\helper\serverurlhelper::class)
+            && ! $container->has(\Zend\Expressive\Helper\ServerUrlHelper::class)
         ) {
             throw new Exception\MissingHelperException(sprintf(
                 '%s requires a %s service at instantiation; none found',
@@ -37,7 +37,7 @@ class ServerUrlMiddlewareFactory
         return new ServerUrlMiddleware(
             $container->has(ServerUrlHelper::class)
                 ? $container->get(ServerUrlHelper::class)
-                : $container->get(\zend\expressive\helper\serverurlhelper::class)
+                : $container->get(\Zend\Expressive\Helper\ServerUrlHelper::class)
         );
     }
 }

--- a/src/Template/TemplateVariableContainer.php
+++ b/src/Template/TemplateVariableContainer.php
@@ -100,6 +100,8 @@ class TemplateVariableContainer implements Countable
     }
 
     /**
+     * @param mixed $value
+     *
      * @return self Returns a new instance that contains the given key/value pair
      */
     public function with(string $key, $value): self

--- a/src/Template/TemplateVariableContainer.php
+++ b/src/Template/TemplateVariableContainer.php
@@ -101,7 +101,6 @@ class TemplateVariableContainer implements Countable
 
     /**
      * @param mixed $value
-     *
      * @return self Returns a new instance that contains the given key/value pair
      */
     public function with(string $key, $value): self

--- a/src/Template/TemplateVariableContainer.php
+++ b/src/Template/TemplateVariableContainer.php
@@ -12,6 +12,10 @@ namespace Mezzio\Helper\Template;
 
 use Countable;
 
+use function array_key_exists;
+use function array_merge;
+use function count;
+
 /**
  * Container for managing template variables within a middleware pipeline.
  *
@@ -73,12 +77,10 @@ use Countable;
  */
 class TemplateVariableContainer implements Countable
 {
-    /**
-     * @var array<string, mixed>
-     */
+    /** @var array<string, mixed> */
     private $variables = [];
 
-    public function count() : int
+    public function count(): int
     {
         return count($this->variables);
     }
@@ -92,7 +94,7 @@ class TemplateVariableContainer implements Countable
         return $this->variables[$key] ?? null;
     }
 
-    public function has(string $key) : bool
+    public function has(string $key): bool
     {
         return array_key_exists($key, $this->variables);
     }
@@ -100,9 +102,9 @@ class TemplateVariableContainer implements Countable
     /**
      * @return self Returns a new instance that contains the given key/value pair
      */
-    public function with(string $key, $value) : self
+    public function with(string $key, $value): self
     {
-        $new = clone $this;
+        $new                  = clone $this;
         $new->variables[$key] = $value;
         return $new;
     }
@@ -110,7 +112,7 @@ class TemplateVariableContainer implements Countable
     /**
      * @return self Returns a new instance with the given key removed.
      */
-    public function without(string $key) : self
+    public function without(string $key): self
     {
         $new = clone $this;
         unset($new->variables[$key]);
@@ -127,9 +129,9 @@ class TemplateVariableContainer implements Countable
      *
      * @return self Returns a new instance with the merged values.
      */
-    public function merge(array $values) : self
+    public function merge(array $values): self
     {
-        $new = clone $this;
+        $new            = clone $this;
         $new->variables = array_merge($this->variables, $values);
         return $new;
     }
@@ -141,7 +143,7 @@ class TemplateVariableContainer implements Countable
      * the container in order to pass the result to the renderer's `render()`
      * method.
      */
-    public function mergeForTemplate(array $values) : array
+    public function mergeForTemplate(array $values): array
     {
         return array_merge($this->variables, $values);
     }

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -29,7 +29,7 @@ class UrlHelper
      *
      * @see RFC 3986: https://tools.ietf.org/html/rfc3986#section-3.5
      */
-    const FRAGMENT_IDENTIFIER_REGEX = '/^([!$&\'()*+,;=._~:@\/?-]|%[0-9a-fA-F]{2}|[a-zA-Z0-9])+$/';
+    public const FRAGMENT_IDENTIFIER_REGEX = '/^([!$&\'()*+,;=._~:@\/?-]|%[0-9a-fA-F]{2}|[a-zA-Z0-9])+$/';
 
     /** @var string */
     private $basePath = '/';
@@ -55,11 +55,11 @@ class UrlHelper
      *     - router (array): contains options to be passed to the router
      *     - reuse_result_params (bool): indicates if the current RouteResult
      *       parameters will be used, defaults to true
-     * @throws Exception\RuntimeException for attempts to use the currently matched
+     * @throws Exception\RuntimeException For attempts to use the currently matched
      *     route but routing failed.
-     * @throws Exception\RuntimeException for attempts to use a matched result
+     * @throws Exception\RuntimeException For attempts to use a matched result
      *     when none has been previously injected in the instance.
-     * @throws InvalidArgumentException for malformed fragment identifiers.
+     * @throws InvalidArgumentException For malformed fragment identifiers.
      */
     public function __invoke(
         ?string $routeName = null,
@@ -177,7 +177,7 @@ class UrlHelper
     }
 
     /**
-     * @throws Exception\RuntimeException if current result is a routing failure.
+     * @throws Exception\RuntimeException If current result is a routing failure.
      */
     private function generateUriFromResult(array $params, RouteResult $result, array $routerOptions): string
     {
@@ -265,7 +265,7 @@ class UrlHelper
     /**
      * Append a fragment to a URI string, if present.
      *
-     * @throws InvalidArgumentException if the fragment identifier is malformed.
+     * @throws InvalidArgumentException If the fragment identifier is malformed.
      */
     private function appendFragment(string $uriString, ?string $fragmentIdentifier): string
     {

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -31,29 +31,18 @@ class UrlHelper
      */
     const FRAGMENT_IDENTIFIER_REGEX = '/^([!$&\'()*+,;=._~:@\/?-]|%[0-9a-fA-F]{2}|[a-zA-Z0-9])+$/';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $basePath = '/';
 
-    /**
-     * @var RouteResult
-     */
+    /** @var RouteResult */
     private $result;
 
-    /**
-     * @var ServerRequestInterface
-     */
+    /** @var ServerRequestInterface */
     private $request;
 
-    /**
-     * @var RouterInterface
-     */
+    /** @var RouterInterface */
     private $router;
 
-    /**
-     * @param RouterInterface $router
-     */
     public function __construct(RouterInterface $router)
     {
         $this->router = $router;
@@ -73,12 +62,12 @@ class UrlHelper
      * @throws InvalidArgumentException for malformed fragment identifiers.
      */
     public function __invoke(
-        string $routeName = null,
+        ?string $routeName = null,
         array $routeParams = [],
         array $queryParams = [],
-        string $fragmentIdentifier = null,
+        ?string $fragmentIdentifier = null,
         array $options = []
-    ) : string {
+    ): string {
         $result = $this->getRouteResult();
         if ($routeName === null && $result === null) {
             throw new Exception\RuntimeException(
@@ -133,12 +122,12 @@ class UrlHelper
      * @see UrlHelper::__invoke()
      */
     public function generate(
-        string $routeName = null,
+        ?string $routeName = null,
         array $routeParams = [],
         array $queryParams = [],
-        string $fragmentIdentifier = null,
+        ?string $fragmentIdentifier = null,
         array $options = []
-    ) : string {
+    ): string {
         return $this($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options);
     }
 
@@ -148,7 +137,7 @@ class UrlHelper
      * When the route result is injected, the helper will use it to seed default
      * parameters if the URL being generated is for the route that was matched.
      */
-    public function setRouteResult(RouteResult $result) : void
+    public function setRouteResult(RouteResult $result): void
     {
         $this->result = $result;
     }
@@ -156,12 +145,12 @@ class UrlHelper
     /**
      * Set the base path to prepend to a generated URI
      */
-    public function setBasePath(string $path) : void
+    public function setBasePath(string $path): void
     {
         $this->basePath = '/' . ltrim($path, '/');
     }
 
-    public function getRouteResult() : ?RouteResult
+    public function getRouteResult(): ?RouteResult
     {
         return $this->result;
     }
@@ -182,7 +171,7 @@ class UrlHelper
     /**
      * Internal accessor for retrieving the base path.
      */
-    public function getBasePath() : string
+    public function getBasePath(): string
     {
         return $this->basePath;
     }
@@ -190,7 +179,7 @@ class UrlHelper
     /**
      * @throws Exception\RuntimeException if current result is a routing failure.
      */
-    private function generateUriFromResult(array $params, RouteResult $result, array $routerOptions) : string
+    private function generateUriFromResult(array $params, RouteResult $result, array $routerOptions): string
     {
         if ($result->isFailure()) {
             throw new Exception\RuntimeException(
@@ -220,7 +209,7 @@ class UrlHelper
      * @param array $params Route parameters
      * @return array Merged parameters
      */
-    private function mergeParams(string $route, RouteResult $result, array $params) : array
+    private function mergeParams(string $route, RouteResult $result, array $params): array
     {
         if ($result->isFailure()) {
             return $params;
@@ -265,7 +254,7 @@ class UrlHelper
     /**
      * Append query string arguments to a URI string, if any are present.
      */
-    private function appendQueryStringArguments(string $uriString, array $queryParams) : string
+    private function appendQueryStringArguments(string $uriString, array $queryParams): string
     {
         if (count($queryParams) > 0) {
             return sprintf('%s?%s', $uriString, http_build_query($queryParams));
@@ -278,7 +267,7 @@ class UrlHelper
      *
      * @throws InvalidArgumentException if the fragment identifier is malformed.
      */
-    private function appendFragment(string $uriString, ?string $fragmentIdentifier) : string
+    private function appendFragment(string $uriString, ?string $fragmentIdentifier): string
     {
         if ($fragmentIdentifier !== null) {
             if (! preg_match(self::FRAGMENT_IDENTIFIER_REGEX, $fragmentIdentifier)) {

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -158,12 +158,12 @@ class UrlHelper
     /**
      * Set request instance
      */
-    public function setRequest(ServerRequestInterface $request) : void
+    public function setRequest(ServerRequestInterface $request): void
     {
         $this->request = $request;
     }
 
-    public function getRequest() : ?ServerRequestInterface
+    public function getRequest(): ?ServerRequestInterface
     {
         return $this->request;
     }
@@ -238,7 +238,7 @@ class UrlHelper
      * @param array $params Params to be merged with request params
      * @return array
      */
-    private function mergeQueryParams(string $route, RouteResult $result, array $params) : array
+    private function mergeQueryParams(string $route, RouteResult $result, array $params): array
     {
         if ($result->isFailure()) {
             return $params;

--- a/src/UrlHelperFactory.php
+++ b/src/UrlHelperFactory.php
@@ -26,7 +26,7 @@ class UrlHelperFactory
     /**
      * Allow serialization
      */
-    public static function __set_state(array $data) : self
+    public static function __set_state(array $data): self
     {
         return new self(
             $data['basePath'] ?? '/',
@@ -41,7 +41,7 @@ class UrlHelperFactory
      */
     public function __construct(string $basePath = '/', string $routerServiceName = RouterInterface::class)
     {
-        $this->basePath = $basePath;
+        $this->basePath          = $basePath;
         $this->routerServiceName = $routerServiceName;
     }
 
@@ -50,7 +50,7 @@ class UrlHelperFactory
      *
      * @throws Exception\MissingRouterException
      */
-    public function __invoke(ContainerInterface $container) : UrlHelper
+    public function __invoke(ContainerInterface $container): UrlHelper
     {
         if (! $container->has($this->routerServiceName)) {
             throw new Exception\MissingRouterException(sprintf(

--- a/src/UrlHelperMiddleware.php
+++ b/src/UrlHelperMiddleware.php
@@ -21,9 +21,7 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 class UrlHelperMiddleware implements MiddlewareInterface
 {
-    /**
-     * @var UrlHelper
-     */
+    /** @var UrlHelper */
     private $helper;
 
     public function __construct(UrlHelper $helper)
@@ -37,7 +35,7 @@ class UrlHelperMiddleware implements MiddlewareInterface
      * Inject the UrlHelper instance with a RouteResult, if present as a request attribute.
      * Injects the helper, and then dispatches the next middleware.
      */
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $this->helper->setRequest($request);
 

--- a/src/UrlHelperMiddlewareFactory.php
+++ b/src/UrlHelperMiddlewareFactory.php
@@ -40,8 +40,7 @@ class UrlHelperMiddlewareFactory
     /**
      * Create and return a UrlHelperMiddleware instance.
      *
-     * @throws Exception\MissingHelperException if the UrlHelper service is
-     *     missing
+     * @throws Exception\MissingHelperException If the UrlHelper service is missing.
      */
     public function __invoke(ContainerInterface $container): UrlHelperMiddleware
     {

--- a/src/UrlHelperMiddlewareFactory.php
+++ b/src/UrlHelperMiddlewareFactory.php
@@ -22,7 +22,7 @@ class UrlHelperMiddlewareFactory
     /**
      * Allow serialization
      */
-    public static function __set_state(array $data) : self
+    public static function __set_state(array $data): self
     {
         return new self(
             $data['urlHelperServiceName'] ?? UrlHelper::class
@@ -43,7 +43,7 @@ class UrlHelperMiddlewareFactory
      * @throws Exception\MissingHelperException if the UrlHelper service is
      *     missing
      */
-    public function __invoke(ContainerInterface $container) : UrlHelperMiddleware
+    public function __invoke(ContainerInterface $container): UrlHelperMiddleware
     {
         if (! $container->has($this->urlHelperServiceName)) {
             throw new Exception\MissingHelperException(sprintf(

--- a/test/AttributeAssertionsTrait.php
+++ b/test/AttributeAssertionsTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Helper;
+
+use ReflectionProperty;
+
+trait AttributeAssertionsTrait
+{
+    /** @param mixed $expected */
+    public static function assertAttributeSame($expected, string $attribute, object $object): void
+    {
+        $r = new ReflectionProperty($object, $attribute);
+        $r->setAccessible(true);
+        self::assertSame($expected, $r->getValue($object));
+    }
+
+    /** @param mixed $expected */
+    public static function assertAttributeEquals($expected, string $attribute, object $object): void
+    {
+        $r = new ReflectionProperty($object, $attribute);
+        $r->setAccessible(true);
+        self::assertEquals($expected, $r->getValue($object));
+    }
+
+    /** @param mixed $expected */
+    public static function assertAttributeContains($expected, string $attribute, object $object): void
+    {
+        $r = new ReflectionProperty($object, $attribute);
+        $r->setAccessible(true);
+        self::assertContains($expected, $r->getValue($object));
+    }
+}

--- a/test/BodyParams/BodyParamsMiddlewareTest.php
+++ b/test/BodyParams/BodyParamsMiddlewareTest.php
@@ -22,6 +22,7 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use ReflectionProperty;
+
 use function fopen;
 use function fwrite;
 use function get_class;
@@ -31,14 +32,10 @@ class BodyParamsMiddlewareTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var Stream
-     */
+    /** @var Stream */
     private $body;
 
-    /**
-     * @var BodyParamsMiddleware
-     */
+    /** @var BodyParamsMiddleware */
     private $bodyParams;
 
     public function setUp(): void
@@ -88,7 +85,6 @@ class BodyParamsMiddlewareTest extends TestCase
 
     /**
      * @dataProvider jsonProvider
-     *
      * @param string $contentType
      */
     public function testParsesRawBodyAndPreservesRawBodyInRequestAttribute($contentType)
@@ -123,14 +119,13 @@ class BodyParamsMiddlewareTest extends TestCase
 
     /**
      * @dataProvider notApplicableProvider
-     *
      * @param string $method
      * @param string $contentType
      */
     public function testRequestIsUnchangedWhenBodyParamsMiddlewareIsNotApplicable($method, $contentType)
     {
         $originalRequest = new ServerRequest([], [], '', $method, $this->body, ['Content-type' => $contentType]);
-        $finalRequest = null;
+        $finalRequest    = null;
 
         $this->bodyParams->process(
             $originalRequest,
@@ -158,11 +153,11 @@ class BodyParamsMiddlewareTest extends TestCase
 
     public function testCustomStrategiesCanMatchRequests()
     {
-        $middleware = $this->bodyParams;
-        $serverRequest = new ServerRequest([], [], '', 'PUT', $this->body, ['Content-type' => 'foo/bar']);
-        $expectedReturn = $this->prophesize(ServerRequestInterface::class)->reveal();
+        $middleware       = $this->bodyParams;
+        $serverRequest    = new ServerRequest([], [], '', 'PUT', $this->body, ['Content-type' => 'foo/bar']);
+        $expectedReturn   = $this->prophesize(ServerRequestInterface::class)->reveal();
         $expectedResponse = new Response();
-        $strategy = $this->prophesize(StrategyInterface::class);
+        $strategy         = $this->prophesize(StrategyInterface::class);
         $strategy->match('foo/bar')->willReturn(true);
         $strategy->parse($serverRequest)->willReturn($expectedReturn);
         $middleware->addStrategy($strategy->reveal());
@@ -182,7 +177,7 @@ class BodyParamsMiddlewareTest extends TestCase
     {
         $middleware = $this->bodyParams;
         $middleware->clearStrategies();
-        $serverRequest = new ServerRequest([], [], '', 'PUT', $this->body, ['Content-type' => 'foo/bar']);
+        $serverRequest    = new ServerRequest([], [], '', 'PUT', $this->body, ['Content-type' => 'foo/bar']);
         $expectedResponse = new Response();
 
         $response = $middleware->process(
@@ -200,9 +195,9 @@ class BodyParamsMiddlewareTest extends TestCase
     {
         $expectedException = new MalformedRequestBodyException('malformed request body');
 
-        $middleware = $this->bodyParams;
+        $middleware    = $this->bodyParams;
         $serverRequest = new ServerRequest([], [], '', 'PUT', $this->body, ['Content-type' => 'foo/bar']);
-        $strategy = $this->prophesize(StrategyInterface::class);
+        $strategy      = $this->prophesize(StrategyInterface::class);
         $strategy->match('foo/bar')->willReturn(true);
         $strategy->parse($serverRequest)->willThrow($expectedException);
         $middleware->addStrategy($strategy->reveal());

--- a/test/BodyParams/BodyParamsMiddlewareTest.php
+++ b/test/BodyParams/BodyParamsMiddlewareTest.php
@@ -49,7 +49,7 @@ class BodyParamsMiddlewareTest extends TestCase
         $this->body->rewind();
     }
 
-    private function mockHandler(callable $callback)
+    private function mockHandler(callable $callback): RequestHandlerInterface
     {
         $handler = $this->prophesize(RequestHandlerInterface::class);
 

--- a/test/BodyParams/FormUrlEncodedStrategyTest.php
+++ b/test/BodyParams/FormUrlEncodedStrategyTest.php
@@ -20,9 +20,7 @@ class FormUrlEncodedStrategyTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var FormUrlEncodedStrategy
-     */
+    /** @var FormUrlEncodedStrategy */
     private $strategy;
 
     public function setUp(): void
@@ -42,7 +40,6 @@ class FormUrlEncodedStrategyTest extends TestCase
 
     /**
      * @dataProvider formContentTypes
-     *
      * @param string $contentType
      */
     public function testMatchesFormUrlencodedTypes($contentType)
@@ -62,7 +59,6 @@ class FormUrlEncodedStrategyTest extends TestCase
 
     /**
      * @dataProvider invalidContentTypes
-     *
      * @param string $contentType
      */
     public function testDoesNotMatchNonFormUrlencodedTypes($contentType)

--- a/test/BodyParams/FormUrlEncodedStrategyTest.php
+++ b/test/BodyParams/FormUrlEncodedStrategyTest.php
@@ -28,7 +28,8 @@ class FormUrlEncodedStrategyTest extends TestCase
         $this->strategy = new FormUrlEncodedStrategy();
     }
 
-    public function formContentTypes()
+    /** @return array<array-key, string[]> */
+    public function formContentTypes(): array
     {
         return [
             ['application/x-www-form-urlencoded'],
@@ -40,14 +41,14 @@ class FormUrlEncodedStrategyTest extends TestCase
 
     /**
      * @dataProvider formContentTypes
-     * @param string $contentType
      */
-    public function testMatchesFormUrlencodedTypes($contentType)
+    public function testMatchesFormUrlencodedTypes(string $contentType): void
     {
         $this->assertTrue($this->strategy->match($contentType));
     }
 
-    public function invalidContentTypes()
+    /** @return array<array-key, string[]> */
+    public function invalidContentTypes(): array
     {
         return [
             ['application/x-www-form-urlencoded2'],
@@ -59,14 +60,13 @@ class FormUrlEncodedStrategyTest extends TestCase
 
     /**
      * @dataProvider invalidContentTypes
-     * @param string $contentType
      */
-    public function testDoesNotMatchNonFormUrlencodedTypes($contentType)
+    public function testDoesNotMatchNonFormUrlencodedTypes(string $contentType): void
     {
         $this->assertFalse($this->strategy->match($contentType));
     }
 
-    public function testParseReturnsOriginalRequest()
+    public function testParseReturnsOriginalRequest(): void
     {
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getParsedBody()->willReturn(['test' => 'value']);
@@ -74,7 +74,7 @@ class FormUrlEncodedStrategyTest extends TestCase
         $this->assertSame($request->reveal(), $this->strategy->parse($request->reveal()));
     }
 
-    public function testParseReturnsOriginalRequestIfBodyIsEmpty()
+    public function testParseReturnsOriginalRequestIfBodyIsEmpty(): void
     {
         $stream = $this->prophesize(StreamInterface::class);
         $stream->__toString()->willReturn('');
@@ -86,7 +86,7 @@ class FormUrlEncodedStrategyTest extends TestCase
         $this->assertSame($request->reveal(), $this->strategy->parse($request->reveal()));
     }
 
-    public function testParseReturnsNewRequest()
+    public function testParseReturnsNewRequest(): void
     {
         $body = 'foo=bar&bar=foo';
 

--- a/test/BodyParams/JsonStrategyTest.php
+++ b/test/BodyParams/JsonStrategyTest.php
@@ -17,13 +17,15 @@ use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 
+use function json_last_error;
+
+use const JSON_ERROR_NONE;
+
 class JsonStrategyTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var JsonStrategy
-     */
+    /** @var JsonStrategy */
     private $strategy;
 
     public function setUp(): void
@@ -46,7 +48,6 @@ class JsonStrategyTest extends TestCase
 
     /**
      * @dataProvider jsonContentTypes
-     *
      * @param string $contentType
      */
     public function testMatchesJsonTypes($contentType)
@@ -69,7 +70,6 @@ class JsonStrategyTest extends TestCase
 
     /**
      * @dataProvider invalidContentTypes
-     *
      * @param string $contentType
      */
     public function testDoesNotMatchNonJsonTypes($contentType)
@@ -79,7 +79,7 @@ class JsonStrategyTest extends TestCase
 
     public function testParseReturnsNewRequest()
     {
-        $body = '{"foo":"bar"}';
+        $body   = '{"foo":"bar"}';
         $stream = $this->prophesize(StreamInterface::class);
         $stream->__toString()->willReturn($body);
         $request = $this->prophesize(ServerRequestInterface::class);
@@ -96,7 +96,7 @@ class JsonStrategyTest extends TestCase
 
     public function testThrowsExceptionOnMalformedJsonInRequestBody()
     {
-        $body = '{foobar}';
+        $body   = '{foobar}';
         $stream = $this->prophesize(StreamInterface::class);
         $stream->__toString()->willReturn($body);
         $request = $this->prophesize(ServerRequestInterface::class);
@@ -111,7 +111,7 @@ class JsonStrategyTest extends TestCase
 
     public function testEmptyRequestBodyYieldsNullParsedBodyWithNoExceptionThrown()
     {
-        $body = '';
+        $body   = '';
         $stream = $this->prophesize(StreamInterface::class);
         $stream->__toString()->willReturn($body);
         $request = $this->prophesize(ServerRequestInterface::class);
@@ -131,7 +131,7 @@ class JsonStrategyTest extends TestCase
      */
     public function testEmptyRequestBodyIsNotJsonDecoded(): void
     {
-        $body = '';
+        $body   = '';
         $stream = $this->prophesize(StreamInterface::class);
         $stream->__toString()->willReturn($body);
         $request = $this->prophesize(ServerRequestInterface::class);

--- a/test/BodyParams/JsonStrategyTest.php
+++ b/test/BodyParams/JsonStrategyTest.php
@@ -33,7 +33,8 @@ class JsonStrategyTest extends TestCase
         $this->strategy = new JsonStrategy();
     }
 
-    public function jsonContentTypes()
+    /** @return array<array-key, string[]> */
+    public function jsonContentTypes(): array
     {
         return [
             ['application/json'],
@@ -48,14 +49,14 @@ class JsonStrategyTest extends TestCase
 
     /**
      * @dataProvider jsonContentTypes
-     * @param string $contentType
      */
-    public function testMatchesJsonTypes($contentType)
+    public function testMatchesJsonTypes(string $contentType): void
     {
         $this->assertTrue($this->strategy->match($contentType));
     }
 
-    public function invalidContentTypes()
+    /** @return array<array-key, string[]> */
+    public function invalidContentTypes(): array
     {
         return [
             ['application/json+xml'],
@@ -70,14 +71,13 @@ class JsonStrategyTest extends TestCase
 
     /**
      * @dataProvider invalidContentTypes
-     * @param string $contentType
      */
-    public function testDoesNotMatchNonJsonTypes($contentType)
+    public function testDoesNotMatchNonJsonTypes(string $contentType): void
     {
         $this->assertFalse($this->strategy->match($contentType));
     }
 
-    public function testParseReturnsNewRequest()
+    public function testParseReturnsNewRequest(): void
     {
         $body   = '{"foo":"bar"}';
         $stream = $this->prophesize(StreamInterface::class);
@@ -94,7 +94,7 @@ class JsonStrategyTest extends TestCase
         $this->assertSame($request->reveal(), $this->strategy->parse($request->reveal()));
     }
 
-    public function testThrowsExceptionOnMalformedJsonInRequestBody()
+    public function testThrowsExceptionOnMalformedJsonInRequestBody(): void
     {
         $body   = '{foobar}';
         $stream = $this->prophesize(StreamInterface::class);
@@ -109,7 +109,7 @@ class JsonStrategyTest extends TestCase
         $this->strategy->parse($request->reveal());
     }
 
-    public function testEmptyRequestBodyYieldsNullParsedBodyWithNoExceptionThrown()
+    public function testEmptyRequestBodyYieldsNullParsedBodyWithNoExceptionThrown(): void
     {
         $body   = '';
         $stream = $this->prophesize(StreamInterface::class);

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -19,17 +19,15 @@ use PHPUnit\Framework\TestCase;
 
 class ConfigProviderTest extends TestCase
 {
-    /**
-     * @var ConfigProvider
-     */
+    /** @var ConfigProvider */
     private $provider;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
         $this->provider = new ConfigProvider();
     }
 
-    public function testInvocationReturnsArray() : array
+    public function testInvocationReturnsArray(): array
     {
         $config = ($this->provider)();
         $this->assertIsArray($config);
@@ -40,7 +38,7 @@ class ConfigProviderTest extends TestCase
     /**
      * @depends testInvocationReturnsArray
      */
-    public function testReturnedArrayContainsDependencies(array $config) : void
+    public function testReturnedArrayContainsDependencies(array $config): void
     {
         $this->assertArrayHasKey('dependencies', $config);
         $this->assertIsArray($config['dependencies']);

--- a/test/ContentLengthMiddlewareTest.php
+++ b/test/ContentLengthMiddlewareTest.php
@@ -25,8 +25,8 @@ class ContentLengthMiddlewareTest extends TestCase
     public function setUp(): void
     {
         $this->response = $response = $this->prophesize(ResponseInterface::class);
-        $this->request = $request = $this->prophesize(ServerRequestInterface::class)->reveal();
-        $this->stream = $this->prophesize(StreamInterface::class);
+        $this->request  = $request = $this->prophesize(ServerRequestInterface::class)->reveal();
+        $this->stream   = $this->prophesize(StreamInterface::class);
 
         $handler = $this->prophesize(RequestHandlerInterface::class);
         $handler->handle($request)->will([$response, 'reveal']);

--- a/test/ContentLengthMiddlewareTest.php
+++ b/test/ContentLengthMiddlewareTest.php
@@ -35,14 +35,14 @@ class ContentLengthMiddlewareTest extends TestCase
         $this->middleware = new ContentLengthMiddleware();
     }
 
-    public function testReturnsResponseVerbatimIfContentLengthHeaderPresent()
+    public function testReturnsResponseVerbatimIfContentLengthHeaderPresent(): void
     {
         $this->response->hasHeader('Content-Length')->willReturn(true);
         $response = $this->middleware->process($this->request, $this->handler);
         $this->assertSame($this->response->reveal(), $response);
     }
 
-    public function testReturnsResponseVerbatimIfContentLengthHeaderNotPresentAndBodySizeIsNull()
+    public function testReturnsResponseVerbatimIfContentLengthHeaderNotPresentAndBodySizeIsNull(): void
     {
         $this->stream->getSize()->willReturn(null);
         $this->response->hasHeader('Content-Length')->willReturn(false);
@@ -52,7 +52,7 @@ class ContentLengthMiddlewareTest extends TestCase
         $this->assertSame($this->response->reveal(), $response);
     }
 
-    public function testReturnsResponseWithContentLengthHeaderBasedOnBodySize()
+    public function testReturnsResponseWithContentLengthHeaderBasedOnBodySize(): void
     {
         $this->stream->getSize()->willReturn(42);
         $this->response->hasHeader('Content-Length')->willReturn(false);

--- a/test/ExceptionTest.php
+++ b/test/ExceptionTest.php
@@ -22,7 +22,7 @@ use function substr;
 
 class ExceptionTest extends TestCase
 {
-    public function exception() : Generator
+    public function exception(): Generator
     {
         $namespace = substr(ExceptionInterface::class, 0, strrpos(ExceptionInterface::class, '\\') + 1);
 
@@ -37,7 +37,7 @@ class ExceptionTest extends TestCase
     /**
      * @dataProvider exception
      */
-    public function testExceptionIsInstanceOfExceptionInterface(string $exception) : void
+    public function testExceptionIsInstanceOfExceptionInterface(string $exception): void
     {
         self::assertStringContainsString('Exception', $exception);
         self::assertTrue(is_a($exception, ExceptionInterface::class, true));

--- a/test/ServerUrlHelperTest.php
+++ b/test/ServerUrlHelperTest.php
@@ -34,7 +34,6 @@ class ServerUrlHelperTest extends TestCase
 
     /**
      * @dataProvider plainPaths
-     *
      * @param null|string $path
      * @param string $expected
      */
@@ -58,8 +57,6 @@ class ServerUrlHelperTest extends TestCase
 
     /**
      * @dataProvider plainPathsForUseWithUri
-     *
-     * @param UriInterface $uri
      * @param null|string $path
      * @param string $expected
      */
@@ -84,8 +81,6 @@ class ServerUrlHelperTest extends TestCase
 
     /**
      * @dataProvider uriWithQueryString
-     *
-     * @param UriInterface $uri
      * @param null|string $path
      * @param string $expected
      */
@@ -110,8 +105,6 @@ class ServerUrlHelperTest extends TestCase
 
     /**
      * @dataProvider uriWithFragment
-     *
-     * @param UriInterface $uri
      * @param null|string $path
      * @param string $expected
      */
@@ -135,8 +128,6 @@ class ServerUrlHelperTest extends TestCase
 
     /**
      * @dataProvider pathsWithQueryString
-     *
-     * @param UriInterface $uri
      * @param string $path
      * @param string $expected
      */
@@ -160,8 +151,6 @@ class ServerUrlHelperTest extends TestCase
 
     /**
      * @dataProvider pathsWithFragment
-     *
-     * @param UriInterface $uri
      * @param string $path
      * @param string $expected
      */

--- a/test/ServerUrlHelperTest.php
+++ b/test/ServerUrlHelperTest.php
@@ -21,7 +21,8 @@ class ServerUrlHelperTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    public function plainPaths()
+    /** @return array<string, string|null[]> */
+    public function plainPaths(): array
     {
         return [
             'null'          => [null,       '/'],
@@ -34,16 +35,15 @@ class ServerUrlHelperTest extends TestCase
 
     /**
      * @dataProvider plainPaths
-     * @param null|string $path
-     * @param string $expected
      */
-    public function testInvocationReturnsPathOnlyIfNoUriInjected($path, $expected)
+    public function testInvocationReturnsPathOnlyIfNoUriInjected(?string $path, string $expected): void
     {
         $helper = new ServerUrlHelper();
         $this->assertEquals($expected, $helper($path));
     }
 
-    public function plainPathsForUseWithUri()
+    /** @return array<string, Uri|string|null[]> */
+    public function plainPathsForUseWithUri(): array
     {
         $uri = new Uri('https://example.com/resource');
         return [
@@ -57,17 +57,19 @@ class ServerUrlHelperTest extends TestCase
 
     /**
      * @dataProvider plainPathsForUseWithUri
-     * @param null|string $path
-     * @param string $expected
      */
-    public function testInvocationReturnsUriComposingPathWhenUriInjected(UriInterface $uri, $path, $expected)
-    {
+    public function testInvocationReturnsUriComposingPathWhenUriInjected(
+        UriInterface $uri,
+        ?string $path,
+        string $expected
+    ): void {
         $helper = new ServerUrlHelper();
         $helper->setUri($uri);
         $this->assertEquals((string) $expected, $helper($path));
     }
 
-    public function uriWithQueryString()
+    /** @return array<string, Uri|string|null[]> */
+    public function uriWithQueryString(): array
     {
         $uri = new Uri('https://example.com/resource?bar=baz');
         return [
@@ -81,17 +83,16 @@ class ServerUrlHelperTest extends TestCase
 
     /**
      * @dataProvider uriWithQueryString
-     * @param null|string $path
-     * @param string $expected
      */
-    public function testStripsQueryStringFromInjectedUri(UriInterface $uri, $path, $expected)
+    public function testStripsQueryStringFromInjectedUri(UriInterface $uri, ?string $path, string $expected): void
     {
         $helper = new ServerUrlHelper();
         $helper->setUri($uri);
         $this->assertEquals($expected, $helper($path));
     }
 
-    public function uriWithFragment()
+    /** @return array<string, Uri|string|null[]> */
+    public function uriWithFragment(): array
     {
         $uri = new Uri('https://example.com/resource#bar');
         return [
@@ -105,17 +106,16 @@ class ServerUrlHelperTest extends TestCase
 
     /**
      * @dataProvider uriWithFragment
-     * @param null|string $path
-     * @param string $expected
      */
-    public function testStripsFragmentFromInjectedUri(UriInterface $uri, $path, $expected)
+    public function testStripsFragmentFromInjectedUri(UriInterface $uri, ?string $path, string $expected): void
     {
         $helper = new ServerUrlHelper();
         $helper->setUri($uri);
         $this->assertEquals($expected, $helper($path));
     }
 
-    public function pathsWithQueryString()
+    /** @return array<string, Uri|string|null[]> */
+    public function pathsWithQueryString(): array
     {
         $uri = new Uri('https://example.com/resource');
         return [
@@ -128,17 +128,16 @@ class ServerUrlHelperTest extends TestCase
 
     /**
      * @dataProvider pathsWithQueryString
-     * @param string $path
-     * @param string $expected
      */
-    public function testUsesQueryStringFromProvidedPath(UriInterface $uri, $path, $expected)
+    public function testUsesQueryStringFromProvidedPath(UriInterface $uri, ?string $path, string $expected): void
     {
         $helper = new ServerUrlHelper();
         $helper->setUri($uri);
         $this->assertEquals($expected, $helper($path));
     }
 
-    public function pathsWithFragment()
+    /** @return array<string, Uri|string[]> */
+    public function pathsWithFragment(): array
     {
         $uri = new Uri('https://example.com/resource');
         return [
@@ -151,17 +150,15 @@ class ServerUrlHelperTest extends TestCase
 
     /**
      * @dataProvider pathsWithFragment
-     * @param string $path
-     * @param string $expected
      */
-    public function testUsesFragmentFromProvidedPath(UriInterface $uri, $path, $expected)
+    public function testUsesFragmentFromProvidedPath(UriInterface $uri, ?string $path, string $expected): void
     {
         $helper = new ServerUrlHelper();
         $helper->setUri($uri);
         $this->assertEquals($expected, $helper($path));
     }
 
-    public function testGenerateProxiesToInvokeMethod()
+    public function testGenerateProxiesToInvokeMethod(): void
     {
         $path = '/foo';
 

--- a/test/ServerUrlMiddlewareFactoryTest.php
+++ b/test/ServerUrlMiddlewareFactoryTest.php
@@ -24,12 +24,12 @@ class ServerUrlMiddlewareFactoryTest extends TestCase
 
     public function testCreatesAndReturnsMiddlewareWhenHelperIsPresentInContainer()
     {
-        $helper = $this->prophesize(ServerUrlHelper::class);
+        $helper    = $this->prophesize(ServerUrlHelper::class);
         $container = $this->prophesize(ContainerInterface::class);
         $container->has(ServerUrlHelper::class)->willReturn(true);
         $container->get(ServerUrlHelper::class)->willReturn($helper->reveal());
 
-        $factory = new ServerUrlMiddlewareFactory();
+        $factory    = new ServerUrlMiddlewareFactory();
         $middleware = $factory($container->reveal());
         $this->assertInstanceOf(ServerUrlMiddleware::class, $middleware);
     }
@@ -38,7 +38,7 @@ class ServerUrlMiddlewareFactoryTest extends TestCase
     {
         $container = $this->prophesize(ContainerInterface::class);
         $container->has(ServerUrlHelper::class)->willReturn(false);
-        $container->has(\Zend\Expressive\Helper\ServerUrlHelper::class)->willReturn(false);
+        $container->has(\zend\expressive\helper\serverurlhelper::class)->willReturn(false);
 
         $factory = new ServerUrlMiddlewareFactory();
 

--- a/test/ServerUrlMiddlewareFactoryTest.php
+++ b/test/ServerUrlMiddlewareFactoryTest.php
@@ -38,7 +38,7 @@ class ServerUrlMiddlewareFactoryTest extends TestCase
     {
         $container = $this->prophesize(ContainerInterface::class);
         $container->has(ServerUrlHelper::class)->willReturn(false);
-        $container->has(\zend\expressive\helper\serverurlhelper::class)->willReturn(false);
+        $container->has(\Zend\Expressive\Helper\ServerUrlHelper::class)->willReturn(false);
 
         $factory = new ServerUrlMiddlewareFactory();
 

--- a/test/ServerUrlMiddlewareFactoryTest.php
+++ b/test/ServerUrlMiddlewareFactoryTest.php
@@ -22,7 +22,7 @@ class ServerUrlMiddlewareFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function testCreatesAndReturnsMiddlewareWhenHelperIsPresentInContainer()
+    public function testCreatesAndReturnsMiddlewareWhenHelperIsPresentInContainer(): void
     {
         $helper    = $this->prophesize(ServerUrlHelper::class);
         $container = $this->prophesize(ContainerInterface::class);
@@ -34,7 +34,7 @@ class ServerUrlMiddlewareFactoryTest extends TestCase
         $this->assertInstanceOf(ServerUrlMiddleware::class, $middleware);
     }
 
-    public function testRaisesExceptionWhenContainerDoesNotContainHelper()
+    public function testRaisesExceptionWhenContainerDoesNotContainHelper(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
         $container->has(ServerUrlHelper::class)->willReturn(false);

--- a/test/ServerUrlMiddlewareTest.php
+++ b/test/ServerUrlMiddlewareTest.php
@@ -26,7 +26,7 @@ class ServerUrlMiddlewareTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function testMiddlewareInjectsHelperWithUri()
+    public function testMiddlewareInjectsHelperWithUri(): void
     {
         $uri     = $this->prophesize(UriInterface::class);
         $request = $this->prophesize(ServerRequestInterface::class);

--- a/test/ServerUrlMiddlewareTest.php
+++ b/test/ServerUrlMiddlewareTest.php
@@ -28,11 +28,11 @@ class ServerUrlMiddlewareTest extends TestCase
 
     public function testMiddlewareInjectsHelperWithUri()
     {
-        $uri = $this->prophesize(UriInterface::class);
+        $uri     = $this->prophesize(UriInterface::class);
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getUri()->willReturn($uri->reveal());
 
-        $helper = new ServerUrlHelper();
+        $helper     = new ServerUrlHelper();
         $middleware = new ServerUrlMiddleware($helper);
 
         $invoked = false;

--- a/test/Template/RouteTemplateVariableMiddlewareTest.php
+++ b/test/Template/RouteTemplateVariableMiddlewareTest.php
@@ -33,7 +33,7 @@ class RouteTemplateVariableMiddlewareTest extends TestCase
         $this->middleware = new RouteTemplateVariableMiddleware();
     }
 
-    public function testMiddlewareInjectsVariableContainerWithNullRouteIfNoVariableContainerOrRouteResultPresent()
+    public function testMiddlewareInjectsVariableContainerWithNullRouteIfNoVariableContainerOrRouteResultPresent(): void
     {
         $this->request
             ->getAttribute(TemplateVariableContainer::class, Argument::type(TemplateVariableContainer::class))
@@ -82,7 +82,7 @@ class RouteTemplateVariableMiddlewareTest extends TestCase
         );
     }
 
-    public function testMiddlewareWillInjectNullValueForRouteIfNoRouteResultInRequest()
+    public function testMiddlewareWillInjectNullValueForRouteIfNoRouteResultInRequest(): void
     {
         $this->request
             ->getAttribute(TemplateVariableContainer::class, Argument::type(TemplateVariableContainer::class))
@@ -130,7 +130,7 @@ class RouteTemplateVariableMiddlewareTest extends TestCase
         );
     }
 
-    public function testMiddlewareWillInjectRoutePulledFromRequestRouteResult()
+    public function testMiddlewareWillInjectRoutePulledFromRequestRouteResult(): void
     {
         $routeResult = $this->prophesize(RouteResult::class);
 

--- a/test/Template/RouteTemplateVariableMiddlewareTest.php
+++ b/test/Template/RouteTemplateVariableMiddlewareTest.php
@@ -12,14 +12,12 @@ namespace MezzioTest\Helper\Template;
 
 use Mezzio\Helper\Template\RouteTemplateVariableMiddleware;
 use Mezzio\Helper\Template\TemplateVariableContainer;
-use Mezzio\Router\Route;
 use Mezzio\Router\RouteResult;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 class RouteTemplateVariableMiddlewareTest extends TestCase

--- a/test/Template/TemplateVariableContainerMiddlewareTest.php
+++ b/test/Template/TemplateVariableContainerMiddlewareTest.php
@@ -31,7 +31,7 @@ class TemplateVariableContainerMiddlewareTest extends TestCase
         $this->middleware = new TemplateVariableContainerMiddleware();
     }
 
-    public function testProcessInjectsVariableContainerIntoRequestPassedToHandler()
+    public function testProcessInjectsVariableContainerIntoRequestPassedToHandler(): void
     {
         $this->request
             ->getAttribute(TemplateVariableContainer::class)
@@ -65,7 +65,7 @@ class TemplateVariableContainerMiddlewareTest extends TestCase
         );
     }
 
-    public function testProcessIsANoOpIfVariableContainerIsAlreadyInRequest()
+    public function testProcessIsANoOpIfVariableContainerIsAlreadyInRequest(): void
     {
         $container = new TemplateVariableContainer();
 

--- a/test/Template/TemplateVariableContainerTest.php
+++ b/test/Template/TemplateVariableContainerTest.php
@@ -13,6 +13,8 @@ namespace MezzioTest\Helper\Template;
 use Mezzio\Helper\Template\TemplateVariableContainer;
 use PHPUnit\Framework\TestCase;
 
+use function array_merge;
+
 class TemplateVariableContainerTest extends TestCase
 {
     public function setUp(): void
@@ -25,7 +27,7 @@ class TemplateVariableContainerTest extends TestCase
         $this->assertCount(0, $this->container);
     }
 
-    public function testSettingVariablesReturnsNewInstanceContainingValue() : TemplateVariableContainer
+    public function testSettingVariablesReturnsNewInstanceContainingValue(): TemplateVariableContainer
     {
         $container = $this->container->with('key', 'value');
 

--- a/test/Template/TemplateVariableContainerTest.php
+++ b/test/Template/TemplateVariableContainerTest.php
@@ -22,7 +22,7 @@ class TemplateVariableContainerTest extends TestCase
         $this->container = new TemplateVariableContainer();
     }
 
-    public function testContainerIsEmptyByDefault()
+    public function testContainerIsEmptyByDefault(): void
     {
         $this->assertCount(0, $this->container);
     }
@@ -39,12 +39,12 @@ class TemplateVariableContainerTest extends TestCase
         return $container;
     }
 
-    public function testHasReturnsFalseForUnsetVariables()
+    public function testHasReturnsFalseForUnsetVariables(): void
     {
         $this->assertFalse($this->container->has('key'));
     }
 
-    public function testGetReturnsNullForUnsetVariables()
+    public function testGetReturnsNullForUnsetVariables(): void
     {
         $this->assertNull($this->container->get('key'));
     }
@@ -52,7 +52,7 @@ class TemplateVariableContainerTest extends TestCase
     /**
      * @depends testSettingVariablesReturnsNewInstanceContainingValue
      */
-    public function testCallingWithoutReturnsNewInstanceWithoutValue(TemplateVariableContainer $original)
+    public function testCallingWithoutReturnsNewInstanceWithoutValue(TemplateVariableContainer $original): void
     {
         $container = $original->without('key');
 
@@ -61,7 +61,7 @@ class TemplateVariableContainerTest extends TestCase
         $this->assertFalse($container->has('key'));
     }
 
-    public function testMergeReturnsNewInstanceContainingMergedArray()
+    public function testMergeReturnsNewInstanceContainingMergedArray(): void
     {
         $values = [
             'foo' => 'bar',
@@ -81,7 +81,7 @@ class TemplateVariableContainerTest extends TestCase
         }
     }
 
-    public function testWillReturnArrayWhenRequestedToMergeForTemplate()
+    public function testWillReturnArrayWhenRequestedToMergeForTemplate(): void
     {
         $containerValues = [
             'foo' => 'bar',

--- a/test/UrlHelperFactoryTest.php
+++ b/test/UrlHelperFactoryTest.php
@@ -18,10 +18,10 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
-use ReflectionProperty;
 
 class UrlHelperFactoryTest extends TestCase
 {
+    use AttributeAssertionsTrait;
     use ProphecyTrait;
 
     /** @var RouterInterface|ObjectProphecy */
@@ -41,13 +41,13 @@ class UrlHelperFactoryTest extends TestCase
         $this->factory = new UrlHelperFactory();
     }
 
-    public function injectContainerService($name, $service)
+    public function injectContainerService(string $name, object $service): void
     {
         $this->container->has($name)->willReturn(true);
         $this->container->get($name)->willReturn($service);
     }
 
-    public function testFactoryReturnsHelperWithRouterInjected()
+    public function testFactoryReturnsHelperWithRouterInjected(): UrlHelper
     {
         $this->injectContainerService(RouterInterface::class, $this->router->reveal());
 
@@ -60,18 +60,18 @@ class UrlHelperFactoryTest extends TestCase
     /**
      * @depends testFactoryReturnsHelperWithRouterInjected
      */
-    public function testHelperUsesDefaultBasePathWhenNoneProvidedAtInstantiation(UrlHelper $helper)
+    public function testHelperUsesDefaultBasePathWhenNoneProvidedAtInstantiation(UrlHelper $helper): void
     {
         $this->assertEquals('/', $helper->getBasePath());
     }
 
-    public function testFactoryRaisesExceptionWhenRouterIsNotPresentInContainer()
+    public function testFactoryRaisesExceptionWhenRouterIsNotPresentInContainer(): void
     {
         $this->expectException(MissingRouterException::class);
         $this->factory->__invoke($this->container->reveal());
     }
 
-    public function testFactoryUsesBasePathAndRouterServiceProvidedAtInstantiation()
+    public function testFactoryUsesBasePathAndRouterServiceProvidedAtInstantiation(): void
     {
         $this->injectContainerService(Router::class, $this->router->reveal());
         $factory = new UrlHelperFactory('/api', Router::class);
@@ -83,7 +83,7 @@ class UrlHelperFactoryTest extends TestCase
         $this->assertEquals('/api', $helper->getBasePath());
     }
 
-    public function testFactoryAllowsSerialization()
+    public function testFactoryAllowsSerialization(): void
     {
         $factory = UrlHelperFactory::__set_state([
             'basePath'          => '/api',
@@ -93,12 +93,5 @@ class UrlHelperFactoryTest extends TestCase
         $this->assertInstanceOf(UrlHelperFactory::class, $factory);
         $this->assertAttributeSame('/api', 'basePath', $factory);
         $this->assertAttributeSame(Router::class, 'routerServiceName', $factory);
-    }
-
-    private function assertAttributeSame($expected, $attribute, $object)
-    {
-        $r = new ReflectionProperty($object, $attribute);
-        $r->setAccessible(true);
-        self::assertSame($expected, $r->getValue($object));
     }
 }

--- a/test/UrlHelperFactoryTest.php
+++ b/test/UrlHelperFactoryTest.php
@@ -24,24 +24,18 @@ class UrlHelperFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var RouterInterface|ObjectProphecy
-     */
+    /** @var RouterInterface|ObjectProphecy */
     private $router;
 
-    /**
-     * @var ContainerInterface|ObjectProphecy
-     */
+    /** @var ContainerInterface|ObjectProphecy */
     private $container;
 
-    /**
-     * @var UrlHelperFactory
-     */
+    /** @var UrlHelperFactory */
     private $factory;
 
     public function setUp(): void
     {
-        $this->router = $this->prophesize(RouterInterface::class);
+        $this->router    = $this->prophesize(RouterInterface::class);
         $this->container = $this->prophesize(ContainerInterface::class);
 
         $this->factory = new UrlHelperFactory();
@@ -92,7 +86,7 @@ class UrlHelperFactoryTest extends TestCase
     public function testFactoryAllowsSerialization()
     {
         $factory = UrlHelperFactory::__set_state([
-            'basePath' => '/api',
+            'basePath'          => '/api',
             'routerServiceName' => Router::class,
         ]);
 

--- a/test/UrlHelperMiddlewareFactoryTest.php
+++ b/test/UrlHelperMiddlewareFactoryTest.php
@@ -18,10 +18,10 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
-use ReflectionProperty;
 
 class UrlHelperMiddlewareFactoryTest extends TestCase
 {
+    use AttributeAssertionsTrait;
     use ProphecyTrait;
 
     /** @var ContainerInterface|ObjectProphecy */
@@ -32,14 +32,14 @@ class UrlHelperMiddlewareFactoryTest extends TestCase
         $this->container = $this->prophesize(ContainerInterface::class);
     }
 
-    public function injectContainer($name, $service)
+    public function injectContainer(string $name, object $service): void
     {
         $service = $service instanceof ObjectProphecy ? $service->reveal() : $service;
         $this->container->has($name)->willReturn(true);
         $this->container->get($name)->willReturn($service);
     }
 
-    public function testFactoryCreatesAndReturnsMiddlewareWhenHelperIsPresentInContainer()
+    public function testFactoryCreatesAndReturnsMiddlewareWhenHelperIsPresentInContainer(): void
     {
         $helper = $this->prophesize(UrlHelper::class)->reveal();
         $this->injectContainer(UrlHelper::class, $helper);
@@ -50,7 +50,7 @@ class UrlHelperMiddlewareFactoryTest extends TestCase
         $this->assertAttributeSame($helper, 'helper', $middleware);
     }
 
-    public function testFactoryRaisesExceptionWhenContainerDoesNotContainHelper()
+    public function testFactoryRaisesExceptionWhenContainerDoesNotContainHelper(): void
     {
         $this->container->has(UrlHelper::class)->willReturn(false);
         $this->container->has(\Zend\Expressive\Helper\UrlHelper::class)->willReturn(false);
@@ -59,7 +59,7 @@ class UrlHelperMiddlewareFactoryTest extends TestCase
         $factory($this->container->reveal());
     }
 
-    public function testFactoryUsesUrlHelperServiceProvidedAtInstantiation()
+    public function testFactoryUsesUrlHelperServiceProvidedAtInstantiation(): void
     {
         $helper = $this->prophesize(UrlHelper::class)->reveal();
         $this->injectContainer(MyUrlHelper::class, $helper);
@@ -71,7 +71,7 @@ class UrlHelperMiddlewareFactoryTest extends TestCase
         $this->assertAttributeSame($helper, 'helper', $middleware);
     }
 
-    public function testFactoryAllowsSerialization()
+    public function testFactoryAllowsSerialization(): void
     {
         $factory = UrlHelperMiddlewareFactory::__set_state([
             'urlHelperServiceName' => MyUrlHelper::class,
@@ -79,12 +79,5 @@ class UrlHelperMiddlewareFactoryTest extends TestCase
 
         $this->assertInstanceOf(UrlHelperMiddlewareFactory::class, $factory);
         $this->assertAttributeSame(MyUrlHelper::class, 'urlHelperServiceName', $factory);
-    }
-
-    private function assertAttributeSame($expected, $attribute, $object)
-    {
-        $r = new ReflectionProperty($object, $attribute);
-        $r->setAccessible(true);
-        self::assertSame($expected, $r->getValue($object));
     }
 }

--- a/test/UrlHelperMiddlewareFactoryTest.php
+++ b/test/UrlHelperMiddlewareFactoryTest.php
@@ -24,9 +24,7 @@ class UrlHelperMiddlewareFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var ContainerInterface|ObjectProphecy
-     */
+    /** @var ContainerInterface|ObjectProphecy */
     private $container;
 
     public function setUp(): void
@@ -46,7 +44,7 @@ class UrlHelperMiddlewareFactoryTest extends TestCase
         $helper = $this->prophesize(UrlHelper::class)->reveal();
         $this->injectContainer(UrlHelper::class, $helper);
 
-        $factory = new UrlHelperMiddlewareFactory();
+        $factory    = new UrlHelperMiddlewareFactory();
         $middleware = $factory($this->container->reveal());
         $this->assertInstanceOf(UrlHelperMiddleware::class, $middleware);
         $this->assertAttributeSame($helper, 'helper', $middleware);

--- a/test/UrlHelperMiddlewareTest.php
+++ b/test/UrlHelperMiddlewareTest.php
@@ -33,12 +33,12 @@ class UrlHelperMiddlewareTest extends TestCase
         $this->helper = $this->prophesize(UrlHelper::class);
     }
 
-    public function createMiddleware()
+    public function createMiddleware(): UrlHelperMiddleware
     {
         return new UrlHelperMiddleware($this->helper->reveal());
     }
 
-    public function testInvocationInjectsHelperWithRouteResultWhenPresentInRequest()
+    public function testInvocationInjectsHelperWithRouteResultWhenPresentInRequest(): void
     {
         $response = $this->prophesize(ResponseInterface::class);
 
@@ -58,7 +58,7 @@ class UrlHelperMiddlewareTest extends TestCase
         ));
     }
 
-    public function testInvocationDoesNotInjectHelperWithRouteResultWhenAbsentInRequest()
+    public function testInvocationDoesNotInjectHelperWithRouteResultWhenAbsentInRequest(): void
     {
         $response = $this->prophesize(ResponseInterface::class);
 

--- a/test/UrlHelperMiddlewareTest.php
+++ b/test/UrlHelperMiddlewareTest.php
@@ -25,9 +25,7 @@ class UrlHelperMiddlewareTest extends TestCase
 {
     use ProphecyTrait;
 
-    /**
-     * @var UrlHelper|ObjectProphecy
-     */
+    /** @var UrlHelper|ObjectProphecy */
     private $helper;
 
     public function setUp(): void
@@ -45,7 +43,7 @@ class UrlHelperMiddlewareTest extends TestCase
         $response = $this->prophesize(ResponseInterface::class);
 
         $routeResult = $this->prophesize(RouteResult::class)->reveal();
-        $request = $this->prophesize(ServerRequestInterface::class);
+        $request     = $this->prophesize(ServerRequestInterface::class);
         $request->getAttribute(RouteResult::class, false)->willReturn($routeResult);
         $this->helper->setRouteResult($routeResult)->shouldBeCalled();
         $this->helper->setRequest($request)->shouldBeCalled();

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -22,13 +22,12 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\RequestHandlerInterface;
-use ReflectionProperty;
 use stdClass;
 use TypeError;
 
 class UrlHelperTest extends TestCase
 {
+    use AttributeAssertionsTrait;
     use MockeryPHPUnitIntegration;
     use ProphecyTrait;
 
@@ -40,7 +39,7 @@ class UrlHelperTest extends TestCase
         $this->router = $this->prophesize(RouterInterface::class);
     }
 
-    public function createHelper()
+    public function createHelper(): UrlHelper
     {
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getQueryParams()->willReturn([]);
@@ -50,7 +49,7 @@ class UrlHelperTest extends TestCase
         return $helper;
     }
 
-    public function testRaisesExceptionOnInvocationIfNoRouteProvidedAndNoResultPresent()
+    public function testRaisesExceptionOnInvocationIfNoRouteProvidedAndNoResultPresent(): void
     {
         $helper = $this->createHelper();
 
@@ -59,19 +58,21 @@ class UrlHelperTest extends TestCase
         $helper();
     }
 
-    public function testRaisesExceptionOnInvocationIfNoRouteProvidedAndResultIndicatesFailure()
+    public function testRaisesExceptionOnInvocationIfNoRouteProvidedAndResultIndicatesFailure(): void
     {
-        $result = $this->prophesize(RouteResult::class);
-        $result->isFailure()->willReturn(true);
+        $result = $this->createMock(RouteResult::class);
+        $result->expects(self::atLeastOnce())
+            ->method('isFailure')
+            ->willReturn(true);
         $helper = $this->createHelper();
-        $helper->setRouteResult($result->reveal());
+        $helper->setRouteResult($result);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('routing failed');
         $helper();
     }
 
-    public function testRaisesExceptionOnInvocationIfRouterCannotGenerateUriForRouteProvided()
+    public function testRaisesExceptionOnInvocationIfRouterCannotGenerateUriForRouteProvided(): void
     {
         $this->router->generateUri('foo', [], [])->willThrow(RouterException::class);
         $helper = $this->createHelper();
@@ -80,7 +81,7 @@ class UrlHelperTest extends TestCase
         $helper('foo');
     }
 
-    public function testWhenNoRouteProvidedTheHelperUsesComposedResultToGenerateUrl()
+    public function testWhenNoRouteProvidedTheHelperUsesComposedResultToGenerateUrl(): void
     {
         $result = $this->prophesize(RouteResult::class);
         $result->isFailure()->willReturn(false);
@@ -95,7 +96,7 @@ class UrlHelperTest extends TestCase
         $this->assertEquals('URL', $helper());
     }
 
-    public function testWhenNoRouteProvidedTheHelperMergesPassedParametersWithResultParametersToGenerateUrl()
+    public function testWhenNoRouteProvidedTheHelperMergesPassedParametersWithResultParametersToGenerateUrl(): void
     {
         $result = $this->prophesize(RouteResult::class);
         $result->isFailure()->willReturn(false);
@@ -110,14 +111,14 @@ class UrlHelperTest extends TestCase
         $this->assertEquals('URL', $helper(null, ['baz' => 'bat']));
     }
 
-    public function testWhenRouteProvidedTheHelperDelegatesToTheRouterToGenerateUrl()
+    public function testWhenRouteProvidedTheHelperDelegatesToTheRouterToGenerateUrl(): void
     {
         $this->router->generateUri('foo', ['bar' => 'baz'], [])->willReturn('URL');
         $helper = $this->createHelper();
         $this->assertEquals('URL', $helper('foo', ['bar' => 'baz']));
     }
 
-    public function testIfRouteResultRouteNameDoesNotMatchRequestedNameItWillNotMergeParamsToGenerateUri()
+    public function testIfRouteResultRouteNameDoesNotMatchRequestedNameItWillNotMergeParamsToGenerateUri(): void
     {
         $result = $this->prophesize(RouteResult::class);
         $result->isFailure()->willReturn(false);
@@ -132,7 +133,7 @@ class UrlHelperTest extends TestCase
         $this->assertEquals('URL', $helper('resource'));
     }
 
-    public function testMergesRouteResultParamsWithProvidedParametersToGenerateUri()
+    public function testMergesRouteResultParamsWithProvidedParametersToGenerateUri(): void
     {
         $result = $this->prophesize(RouteResult::class);
         $result->isFailure()->willReturn(false);
@@ -147,7 +148,7 @@ class UrlHelperTest extends TestCase
         $this->assertEquals('URL', $helper('resource', ['version' => 2]));
     }
 
-    public function testProvidedParametersOverrideAnyPresentInARouteResultWhenGeneratingUri()
+    public function testProvidedParametersOverrideAnyPresentInARouteResultWhenGeneratingUri(): void
     {
         $result = $this->prophesize(RouteResult::class);
         $result->isFailure()->willReturn(false);
@@ -162,7 +163,7 @@ class UrlHelperTest extends TestCase
         $this->assertEquals('URL', $helper('resource', ['id' => 2]));
     }
 
-    public function testWillNotReuseRouteResultParamsIfReuseResultParamsFlagIsFalseWhenGeneratingUri()
+    public function testWillNotReuseRouteResultParamsIfReuseResultParamsFlagIsFalseWhenGeneratingUri(): void
     {
         $result = $this->prophesize(RouteResult::class);
         $result->isFailure()->willReturn(false);
@@ -177,7 +178,7 @@ class UrlHelperTest extends TestCase
         $this->assertEquals('URL', $helper('resource', [], [], null, ['reuse_result_params' => false]));
     }
 
-    public function testCanInjectRouteResult()
+    public function testCanInjectRouteResult(): void
     {
         $result = $this->prophesize(RouteResult::class);
         $helper = $this->createHelper();
@@ -185,21 +186,21 @@ class UrlHelperTest extends TestCase
         $this->assertAttributeSame($result->reveal(), 'result', $helper);
     }
 
-    public function testAllowsSettingBasePath()
+    public function testAllowsSettingBasePath(): void
     {
         $helper = $this->createHelper();
         $helper->setBasePath('/foo');
         $this->assertAttributeEquals('/foo', 'basePath', $helper);
     }
 
-    public function testSlashIsPrependedWhenBasePathDoesNotHaveOne()
+    public function testSlashIsPrependedWhenBasePathDoesNotHaveOne(): void
     {
         $helper = $this->createHelper();
         $helper->setBasePath('foo');
         $this->assertAttributeEquals('/foo', 'basePath', $helper);
     }
 
-    public function testBasePathIsPrependedToGeneratedPath()
+    public function testBasePathIsPrependedToGeneratedPath(): void
     {
         $this->router->generateUri('foo', ['bar' => 'baz'], [])->willReturn('/foo/baz');
         $helper = $this->createHelper();
@@ -207,7 +208,7 @@ class UrlHelperTest extends TestCase
         $this->assertEquals('/prefix/foo/baz', $helper('foo', ['bar' => 'baz']));
     }
 
-    public function testBasePathIsPrependedToGeneratedPathWhenUsingRouteResult()
+    public function testBasePathIsPrependedToGeneratedPathWhenUsingRouteResult(): void
     {
         $result = $this->prophesize(RouteResult::class);
         $result->isFailure()->willReturn(false);
@@ -227,7 +228,7 @@ class UrlHelperTest extends TestCase
         $this->assertEquals('/prefix/foo/baz', $helper());
     }
 
-    public function testGenerateProxiesToInvokeMethod()
+    public function testGenerateProxiesToInvokeMethod(): void
     {
         $routeName          = 'foo';
         $routeParams        = ['bar'];
@@ -247,7 +248,8 @@ class UrlHelperTest extends TestCase
         );
     }
 
-    public function invalidBasePathProvider()
+    /** @return array<array-key, mixed[]> */
+    public function invalidBasePathProvider(): array
     {
         return [
             [new stdClass('foo')],
@@ -259,7 +261,7 @@ class UrlHelperTest extends TestCase
      * @dataProvider invalidBasePathProvider
      * @param mixed $basePath
      */
-    public function testThrowsExceptionWhenSettingInvalidBasePaths($basePath)
+    public function testThrowsExceptionWhenSettingInvalidBasePaths($basePath): void
     {
         $this->expectException(TypeError::class);
 
@@ -267,7 +269,7 @@ class UrlHelperTest extends TestCase
         $helper->setBasePath($basePath);
     }
 
-    public function testIfRouteResultIsFailureItWillNotMergeParamsToGenerateUri()
+    public function testIfRouteResultIsFailureItWillNotMergeParamsToGenerateUri(): void
     {
         $result = $this->prophesize(RouteResult::class);
         $result->isFailure()->willReturn(true);
@@ -282,14 +284,15 @@ class UrlHelperTest extends TestCase
         $this->assertEquals('URL', $helper('resource'));
     }
 
-    public function testOptionsArePassedToRouter()
+    public function testOptionsArePassedToRouter(): void
     {
         $this->router->generateUri('foo', [], ['bar' => 'baz'])->willReturn('URL');
         $helper = $this->createHelper();
         $this->assertEquals('URL', $helper('foo', [], [], null, ['router' => ['bar' => 'baz']]));
     }
 
-    public function queryParametersAndFragmentProvider()
+    /** @return array<string, mixed[]> */
+    public function queryParametersAndFragmentProvider(): array
     {
         return [
             'none'           => [[], null, ''],
@@ -301,12 +304,12 @@ class UrlHelperTest extends TestCase
 
     /**
      * @dataProvider queryParametersAndFragmentProvider
-     * @param array $queryParams
-     * @param null|string $fragmentIdentifier
-     * @param string $expected
      */
-    public function testQueryParametersAndFragment(array $queryParams, $fragmentIdentifier, $expected)
-    {
+    public function testQueryParametersAndFragment(
+        array $queryParams,
+        ?string $fragmentIdentifier,
+        string $expected
+    ): void {
         $this->router->generateUri('foo', ['bar' => 'baz'], [])->willReturn('/foo/baz');
         $helper = $this->createHelper();
 
@@ -316,7 +319,8 @@ class UrlHelperTest extends TestCase
         );
     }
 
-    public function invalidFragmentProvider()
+    /** @return array<array-key, string[]> */
+    public function invalidFragmentProvider(): array
     {
         return [
             [''],
@@ -326,9 +330,8 @@ class UrlHelperTest extends TestCase
 
     /**
      * @dataProvider invalidFragmentProvider
-     * @param string $fragmentIdentifier
      */
-    public function testRejectsInvalidFragmentIdentifier($fragmentIdentifier)
+    public function testRejectsInvalidFragmentIdentifier(string $fragmentIdentifier): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Fragment identifier must conform to RFC 3986');
@@ -344,7 +347,7 @@ class UrlHelperTest extends TestCase
      * Test written when discovering that generate() uses '' as the default fragment,
      * which __invoke() considers invalid.
      */
-    public function testCallingGenerateWithoutFragmentArgumentPassesNullValueForFragment()
+    public function testCallingGenerateWithoutFragmentArgumentPassesNullValueForFragment(): void
     {
         $this->router->generateUri('foo', [], [])->willReturn('/foo');
         $helper = $this->createHelper();
@@ -355,7 +358,7 @@ class UrlHelperTest extends TestCase
     /**
      * @group 42
      */
-    public function testAppendsQueryStringAndFragmentWhenPresentAndRouteNameIsNotProvided()
+    public function testAppendsQueryStringAndFragmentWhenPresentAndRouteNameIsNotProvided(): void
     {
         $result = $this->prophesize(RouteResult::class);
         $result->isFailure()->willReturn(false);
@@ -384,13 +387,13 @@ class UrlHelperTest extends TestCase
         );
     }
 
-    public function testGetRouteResultIfNoRouteResultSet()
+    public function testGetRouteResultIfNoRouteResultSet(): void
     {
         $helper = $this->createHelper();
         $this->assertNull($helper->getRouteResult());
     }
 
-    public function testGetRouteResultWithRouteResultSet()
+    public function testGetRouteResultWithRouteResultSet(): void
     {
         $helper = $this->createHelper();
         $result = $this->prophesize(RouteResult::class);
@@ -399,7 +402,7 @@ class UrlHelperTest extends TestCase
         $this->assertInstanceOf(RouteResult::class, $helper->getRouteResult());
     }
 
-    public function testWillNotReuseQueryParamsIfReuseQueryParamsFlagIsFalseWhenGeneratingUri()
+    public function testWillNotReuseQueryParamsIfReuseQueryParamsFlagIsFalseWhenGeneratingUri(): void
     {
         $result = $this->prophesize(RouteResult::class);
         $result->isFailure()->willReturn(false);
@@ -418,7 +421,7 @@ class UrlHelperTest extends TestCase
         $this->assertEquals('URL', $helper('resource', [], [], null, ['reuse_query_params' => false]));
     }
 
-    public function testWillReuseQueryParamsIfReuseQueryParamsFlagIsTrueWhenGeneratingUri()
+    public function testWillReuseQueryParamsIfReuseQueryParamsFlagIsTrueWhenGeneratingUri(): void
     {
         $result = $this->prophesize(RouteResult::class);
         $result->isFailure()->willReturn(false);
@@ -437,7 +440,7 @@ class UrlHelperTest extends TestCase
         $this->assertEquals('URL?foo=bar', $helper('resource', [], [], null, ['reuse_query_params' => true]));
     }
 
-    public function testWillNotReuseQueryParamsIfReuseQueryParamsFlagIsMissingGeneratingUri()
+    public function testWillNotReuseQueryParamsIfReuseQueryParamsFlagIsMissingGeneratingUri(): void
     {
         $result = $this->prophesize(RouteResult::class);
         $result->isFailure()->willReturn(false);
@@ -456,7 +459,7 @@ class UrlHelperTest extends TestCase
         $this->assertEquals('URL', $helper('resource'));
     }
 
-    public function testCanOverrideRequestQueryParams()
+    public function testCanOverrideRequestQueryParams(): void
     {
         $result = $this->prophesize(RouteResult::class);
         $result->isFailure()->willReturn(false);
@@ -473,19 +476,5 @@ class UrlHelperTest extends TestCase
         $helper->setRequest($request->reveal());
 
         $this->assertEquals('URL?foo=foo', $helper('resource', [], ['foo' => 'foo']));
-    }
-
-    private function assertAttributeSame($expected, $attribute, $object)
-    {
-        $r = new ReflectionProperty($object, $attribute);
-        $r->setAccessible(true);
-        self::assertSame($expected, $r->getValue($object));
-    }
-
-    private function assertAttributeEquals($expected, $attribute, $object)
-    {
-        $r = new ReflectionProperty($object, $attribute);
-        $r->setAccessible(true);
-        self::assertEquals($expected, $r->getValue($object));
     }
 }

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -29,13 +29,10 @@ use TypeError;
 
 class UrlHelperTest extends TestCase
 {
+    use MockeryPHPUnitIntegration;
     use ProphecyTrait;
 
-    use MockeryPHPUnitIntegration;
-
-    /**
-     * @var RouterInterface|ObjectProphecy
-     */
+    /** @var RouterInterface|ObjectProphecy */
     private $router;
 
     public function setUp(): void
@@ -232,11 +229,11 @@ class UrlHelperTest extends TestCase
 
     public function testGenerateProxiesToInvokeMethod()
     {
-        $routeName = 'foo';
-        $routeParams = ['bar'];
-        $queryParams = ['foo' => 'bar'];
+        $routeName          = 'foo';
+        $routeParams        = ['bar'];
+        $queryParams        = ['foo' => 'bar'];
         $fragmentIdentifier = 'foobar';
-        $options = ['router' => ['foobar' => 'baz'], 'reuse_result_params' => false];
+        $options            = ['router' => ['foobar' => 'baz'], 'reuse_result_params' => false];
 
         $helper = Mockery::mock(UrlHelper::class)->makePartial();
         $helper->shouldReceive('__invoke')
@@ -260,7 +257,6 @@ class UrlHelperTest extends TestCase
 
     /**
      * @dataProvider invalidBasePathProvider
-     *
      * @param mixed $basePath
      */
     public function testThrowsExceptionWhenSettingInvalidBasePaths($basePath)
@@ -305,7 +301,6 @@ class UrlHelperTest extends TestCase
 
     /**
      * @dataProvider queryParametersAndFragmentProvider
-     *
      * @param array $queryParams
      * @param null|string $fragmentIdentifier
      * @param string $expected
@@ -331,7 +326,6 @@ class UrlHelperTest extends TestCase
 
     /**
      * @dataProvider invalidFragmentProvider
-     *
      * @param string $fragmentIdentifier
      */
     public function testRejectsInvalidFragmentIdentifier($fragmentIdentifier)


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

Updates to Laminas Coding Standard 2 and adds `ext-json` to require.

Fixes #3 - Adds `vimeo/psalm` to dev dependencies and sets baseline.

In `src` nearly all changes are cosmetic with the exception of the following:

- ServerUrlHelper::__invoke() signature change from `string $path = null` to `?string $path = null`
- ServerUrlHelper::generate() signature change from `string $path = null` to `?string $path = null`
- UrlHelper::__invoke() signature change. $routeName and $fragmentIdentifier both nullable
- MalformedRequestBodyException::__construct() signature changed from `($message, Exception $previous = null)` to (string $message, ?Exception $previous = null)

In `test` I've added a trait to collect removed PHPUnit assertions for `assertAttribute*()` so they can more easily be found later on.
