### PR TITLE
hotfix/reuse_query_params_default

### DIFF
--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -108,7 +108,7 @@ class UrlHelper
             $routeParams = $this->mergeParams($routeName, $result, $routeParams);
         }
 
-        $reuseQueryParams = ! isset($options['reuse_query_params']) || (bool) $options['reuse_query_params'];
+        $reuseQueryParams = isset($options['reuse_query_params']) ? (bool) $options['reuse_query_params'] : false;
 
         if ($result && $reuseQueryParams) {
             // Merge current request params with passed query params

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -443,7 +443,7 @@ class UrlHelperTest extends TestCase
         $this->assertEquals('URL?foo=bar', $helper('resource', [], [], null, ['reuse_query_params' => true]));
     }
 
-    public function testWillReuseQueryParamsIfReuseQueryParamsFlagIsMissingGeneratingUri()
+    public function testWillNotReuseQueryParamsIfReuseQueryParamsFlagIsMissingGeneratingUri()
     {
         $result = $this->prophesize(RouteResult::class);
         $result->isFailure()->willReturn(false);
@@ -459,7 +459,7 @@ class UrlHelperTest extends TestCase
         $helper->setRouteResult($result->reveal());
         $helper->setRequest($request->reveal());
 
-        $this->assertEquals('URL?foo=bar', $helper('resource'));
+        $this->assertEquals('URL', $helper('resource'));
     }
 
     public function testCanOverrideRequestQueryParams()


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Hotfix for reuse_query_params, default behaviour was set to enabled which introduces breaking changes. This fix restores default behavior. Tests have been updated to reflect this change.