### PR TITLE
Fix: `ExceptionInterface` cannot be caught

### DIFF
--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Mezzio\Helper\Exception;
 
-interface ExceptionInterface
+use Throwable;
+
+interface ExceptionInterface extends Throwable
 {
 }

--- a/src/Exception/MalformedRequestBodyException.php
+++ b/src/Exception/MalformedRequestBodyException.php
@@ -7,6 +7,7 @@ namespace Mezzio\Helper\Exception;
 use Exception;
 use InvalidArgumentException;
 
+/** @final */
 class MalformedRequestBodyException extends InvalidArgumentException implements ExceptionInterface
 {
     /** @param string $message */

--- a/src/Exception/MissingHelperException.php
+++ b/src/Exception/MissingHelperException.php
@@ -7,6 +7,7 @@ namespace Mezzio\Helper\Exception;
 use DomainException;
 use Psr\Container\ContainerExceptionInterface;
 
+/** @final */
 class MissingHelperException extends DomainException implements
     ContainerExceptionInterface,
     ExceptionInterface

--- a/src/Exception/MissingRouterException.php
+++ b/src/Exception/MissingRouterException.php
@@ -7,6 +7,7 @@ namespace Mezzio\Helper\Exception;
 use DomainException;
 use Psr\Container\ContainerExceptionInterface;
 
+/** @final */
 class MissingRouterException extends DomainException implements
     ContainerExceptionInterface,
     ExceptionInterface

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mezzio\Helper\Exception;
 
+/** @final */
 class RuntimeException extends \RuntimeException implements ExceptionInterface
 {
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | kinda
| BC Break      | not-really, but strictly yes…

### Description

Extends `ExceptionInterface` from `Throwable` so that consumers can catch the marker interface without static analysis errors.

Also marks all existing concrete exceptions as soft `@final` so that the next major can finalise them.
