### PR TITLE
[RFC] Introduce UrlHelperInterface and mark UrlHelper as `@final`

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -6,6 +6,7 @@ namespace Mezzio\Helper;
 
 class ConfigProvider
 {
+    /** @return array<string, mixed> */
     public function __invoke(): array
     {
         return [
@@ -13,6 +14,7 @@ class ConfigProvider
         ];
     }
 
+    /** @return array<string, mixed> */
     public function getDependencies(): array
     {
         return [
@@ -25,6 +27,9 @@ class ConfigProvider
                 ServerUrlMiddleware::class => ServerUrlMiddlewareFactory::class,
                 UrlHelper::class           => UrlHelperFactory::class,
                 UrlHelperMiddleware::class => UrlHelperMiddlewareFactory::class,
+            ],
+            'aliases'    => [
+                UrlHelperInterface::class => UrlHelper::class,
             ],
         ];
     }

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -19,13 +19,10 @@ use function preg_match;
 use function sprintf;
 
 /**
- * @psalm-type UrlGeneratorOptions = array{
- *     router?: array<array-key, mixed>,
- *     reuse_result_params?: bool,
- *     reuse_query_params?: bool,
- * }
+ * @psalm-import-type UrlGeneratorOptions from UrlHelperInterface
+ * @final
  */
-class UrlHelper
+class UrlHelper implements UrlHelperInterface
 {
     /**
      * Regular expression used to validate fragment identifiers.

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -41,21 +41,7 @@ class UrlHelper implements UrlHelperInterface
     {
     }
 
-    /**
-     * Generate a URL based on a given route.
-     *
-     * @param array<string, mixed> $routeParams
-     * @param array<string, mixed> $queryParams
-     * @param UrlGeneratorOptions $options Can have the following keys:
-     *     - router (array): contains options to be passed to the router
-     *     - reuse_result_params (bool): indicates if the current RouteResult
-     *       parameters will be used, defaults to true
-     * @throws Exception\RuntimeException For attempts to use the currently matched
-     *     route but routing failed.
-     * @throws Exception\RuntimeException For attempts to use a matched result
-     *     when none has been previously injected in the instance.
-     * @throws InvalidArgumentException For malformed fragment identifiers.
-     */
+    /** @inheritDoc */
     public function __invoke(
         ?string $routeName = null,
         array $routeParams = [],
@@ -109,17 +95,7 @@ class UrlHelper implements UrlHelperInterface
         return $path;
     }
 
-    /**
-     * Generate a URL based on a given route.
-     *
-     * Proxies to __invoke().
-     *
-     * @see UrlHelper::__invoke()
-     *
-     * @param array<string, mixed> $routeParams
-     * @param array<string, mixed> $queryParams
-     * @param UrlGeneratorOptions $options
-     */
+    /** @inheritDoc */
     public function generate(
         ?string $routeName = null,
         array $routeParams = [],

--- a/src/UrlHelperInterface.php
+++ b/src/UrlHelperInterface.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mezzio\Helper;
+
+use InvalidArgumentException;
+use Mezzio\Router\RouteResult;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * @psalm-type UrlGeneratorOptions = array{
+ *     router?: array<array-key, mixed>,
+ *     reuse_result_params?: bool,
+ *     reuse_query_params?: bool,
+ * }
+ */
+interface UrlHelperInterface
+{
+    /**
+     * Generate a URL based on a given route.
+     *
+     * @param non-empty-string|null $routeName
+     * @param array<string, mixed> $routeParams
+     * @param array<string, mixed> $queryParams
+     * @param UrlGeneratorOptions $options Can have the following keys:
+     *     - router (array): contains options to be passed to the router
+     *     - reuse_result_params (bool): indicates if the current RouteResult parameters will be used, defaults to true
+     *     - reuse_query_params (bool): indicates if the current query parameters will be used, defaults to false
+     * @throws Exception\RuntimeException For attempts to use the currently matched route but routing failed.
+     * @throws Exception\RuntimeException For attempts to use a matched result
+     *     when none has been previously injected in the instance.
+     * @throws InvalidArgumentException For malformed fragment identifiers.
+     */
+    public function __invoke(
+        ?string $routeName = null,
+        array $routeParams = [],
+        array $queryParams = [],
+        ?string $fragmentIdentifier = null,
+        array $options = []
+    ): string;
+
+    /**
+     * Generate a URL based on a given route.
+     *
+     * @param non-empty-string|null $routeName
+     * @param array<string, mixed> $routeParams
+     * @param array<string, mixed> $queryParams
+     * @param UrlGeneratorOptions $options Can have the following keys:
+     *     - router (array): contains options to be passed to the router
+     *     - reuse_result_params (bool): indicates if the current RouteResult parameters will be used, defaults to true
+     *     - reuse_query_params (bool): indicates if the current query parameters will be used, defaults to false
+     * @throws Exception\RuntimeException For attempts to use the currently matched route but routing failed.
+     * @throws Exception\RuntimeException For attempts to use a matched result
+     *     when none has been previously injected in the instance.
+     * @throws InvalidArgumentException For malformed fragment identifiers.
+     */
+    public function generate(
+        ?string $routeName = null,
+        array $routeParams = [],
+        array $queryParams = [],
+        ?string $fragmentIdentifier = null,
+        array $options = []
+    ): string;
+
+    /**
+     * Make the current request available to the helper so that it can re-use query parameters if desired
+     */
+    public function setRequest(ServerRequestInterface $request): void;
+
+    /**
+     * Make the current routing result available to the helper so that it can re-use matched parameters if desired
+     */
+    public function setRouteResult(RouteResult $result): void;
+}

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -11,6 +11,7 @@ use Mezzio\Helper\ServerUrlMiddlewareFactory;
 use Mezzio\Helper\Template\TemplateVariableContainerMiddleware;
 use Mezzio\Helper\UrlHelper;
 use Mezzio\Helper\UrlHelperFactory;
+use Mezzio\Helper\UrlHelperInterface;
 use Mezzio\Helper\UrlHelperMiddleware;
 use Mezzio\Helper\UrlHelperMiddlewareFactory;
 use PHPUnit\Framework\TestCase;
@@ -33,6 +34,9 @@ final class ConfigProviderTest extends TestCase
                     ServerUrlMiddleware::class => ServerUrlMiddlewareFactory::class,
                     UrlHelper::class           => UrlHelperFactory::class,
                     UrlHelperMiddleware::class => UrlHelperMiddlewareFactory::class,
+                ],
+                'aliases'    => [
+                    UrlHelperInterface::class => UrlHelper::class,
                 ],
             ],
         ], $config);

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -359,7 +359,7 @@ final class UrlHelperTest extends TestCase
         self::assertSame('/prefix/foo/baz', $helper());
     }
 
-    public function testGenerateProxiesToInvokeMethod(): void
+    public function testGenerateAndInvokeMethodProduceTheSameResult(): void
     {
         $routeName          = 'foo';
         $routeParams        = ['route' => 'bar'];
@@ -367,44 +367,10 @@ final class UrlHelperTest extends TestCase
         $fragmentIdentifier = 'foobar';
         $options            = ['router' => ['foobar' => 'baz'], 'reuse_result_params' => false];
 
-        $helper = new class ($this->router) extends UrlHelper
-        {
-            public bool $invoked = false;
-
-            /** {@inheritDoc} */
-            public function __invoke(
-                ?string $routeName = null,
-                array $routeParams = [],
-                array $queryParams = [],
-                ?string $fragmentIdentifier = null,
-                array $options = []
-            ): string {
-                $this->invoked = true;
-
-                return 'it worked';
-            }
-
-            /** {@inheritDoc} */
-            public function generate(
-                ?string $routeName = null,
-                array $routeParams = [],
-                array $queryParams = [],
-                ?string $fragmentIdentifier = null,
-                array $options = []
-            ): string {
-                return parent::generate($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options);
-            }
-        };
-
-        self::assertFalse($helper->invoked);
-
-        $generatedPath = $helper->generate($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options);
-
-        self::assertTrue($helper->invoked);
-        self::assertSame('it worked', $generatedPath);
+        $helper = $this->createHelper();
         self::assertSame(
-            'it worked',
-            $helper->__invoke($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options)
+            $helper->__invoke($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options),
+            $helper->generate($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options),
         );
     }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes
| RFC           | yes

### Description

In future this will allow consumers here and elsewhere to accept the interface as a dependency instead of the concrete implementation, enabling UrlHelper to become final whilst providing a safer way of mocking and testing in user projects.
