### PR TITLE
UrlHelperMiddleware: depend on the new interface

### DIFF
--- a/src/UrlHelperMiddleware.php
+++ b/src/UrlHelperMiddleware.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mezzio\Helper;
 
-use Mezzio\Helper\UrlHelper;
 use Mezzio\Router\RouteResult;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -16,7 +15,7 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 class UrlHelperMiddleware implements MiddlewareInterface
 {
-    public function __construct(private UrlHelper $helper)
+    public function __construct(private UrlHelperInterface $helper)
     {
     }
 

--- a/src/UrlHelperMiddlewareFactory.php
+++ b/src/UrlHelperMiddlewareFactory.php
@@ -46,7 +46,7 @@ class UrlHelperMiddlewareFactory
         }
 
         $helper = $container->get($this->urlHelperServiceName);
-        assert($helper instanceof UrlHelper);
+        assert($helper instanceof UrlHelperInterface);
 
         return new UrlHelperMiddleware($helper);
     }

--- a/test/UrlHelperMiddlewareFactoryTest.php
+++ b/test/UrlHelperMiddlewareFactoryTest.php
@@ -6,6 +6,7 @@ namespace MezzioTest\Helper;
 
 use Mezzio\Helper\Exception\MissingHelperException;
 use Mezzio\Helper\UrlHelper;
+use Mezzio\Helper\UrlHelperInterface;
 use Mezzio\Helper\UrlHelperMiddleware;
 use Mezzio\Helper\UrlHelperMiddlewareFactory;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -89,5 +90,17 @@ final class UrlHelperMiddlewareFactoryTest extends TestCase
 
         self::assertInstanceOf(UrlHelperMiddlewareFactory::class, $factory);
         self::assertAttributeSame('MyUrlHelper', 'urlHelperServiceName', $factory);
+    }
+
+    public function testFactoryAllowsCustomUrlHelperInterfaceImplementations(): void
+    {
+        $helper = $this->createMock(UrlHelperInterface::class);
+        $this->injectContainer('MyUrlHelper', $helper);
+        $factory = new UrlHelperMiddlewareFactory('MyUrlHelper');
+
+        $middleware = $factory($this->container);
+
+        self::assertInstanceOf(UrlHelperMiddleware::class, $middleware);
+        self::assertAttributeSame($helper, 'helper', $middleware);
     }
 }

--- a/test/UrlHelperMiddlewareTest.php
+++ b/test/UrlHelperMiddlewareTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MezzioTest\Helper;
 
-use Mezzio\Helper\UrlHelper;
+use Mezzio\Helper\UrlHelperInterface;
 use Mezzio\Helper\UrlHelperMiddleware;
 use Mezzio\Router\RouteResult;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -16,8 +16,8 @@ use Psr\Http\Server\RequestHandlerInterface;
 /** @covers \Mezzio\Helper\UrlHelperMiddleware */
 final class UrlHelperMiddlewareTest extends TestCase
 {
-    /** @var UrlHelper&MockObject */
-    private UrlHelper $helper;
+    /** @var UrlHelperInterface&MockObject */
+    private UrlHelperInterface $helper;
 
     private UrlHelperMiddleware $middleware;
 
@@ -25,7 +25,7 @@ final class UrlHelperMiddlewareTest extends TestCase
     {
         parent::setUp();
 
-        $this->helper = $this->createMock(UrlHelper::class);
+        $this->helper = $this->createMock(UrlHelperInterface::class);
 
         $this->middleware = new UrlHelperMiddleware($this->helper);
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Follow up of https://github.com/mezzio/mezzio-helpers/pull/32

In order to respect the new `@final` tag, both `UrlHelperMiddleware` and `UrlHelperMiddlewareFactory` need to typehint the new interface.

Ping @gsteel 