### PR TITLE
base path returned for nonexistent route instead of throwing exception

### DIFF
--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -65,7 +65,12 @@ class UrlHelper implements UrlHelperInterface
         $routerOptions = $options['router'] ?? [];
 
         if ($routeName === null) {
-            $path = $basePath . $this->generateUriFromResult($routeParams, $result, $routerOptions);
+            $path = $basePath;
+
+            if (! $result->isFailure()) {
+                $path .= $this->generateUriFromResult($routeParams, $result, $routerOptions);
+            }
+
             $path = $this->appendQueryStringArguments($path, $queryParams);
             $path = $this->appendFragment($path, $fragmentIdentifier);
             return $path;
@@ -151,17 +156,8 @@ class UrlHelper implements UrlHelperInterface
         return $this->basePath;
     }
 
-    /**
-     * @throws Exception\RuntimeException If current result is a routing failure.
-     */
     private function generateUriFromResult(array $params, RouteResult $result, array $routerOptions): string
     {
-        if ($result->isFailure()) {
-            throw new Exception\RuntimeException(
-                'Attempting to use matched result when routing failed; aborting'
-            );
-        }
-
         $name = $result->getMatchedRouteName();
         assert(is_string($name)); // Cannot be false if the result is not a failure
         $params = array_merge($result->getMatchedParams(), $params);

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -59,7 +59,7 @@ final class UrlHelperTest extends TestCase
         $helper();
     }
 
-    public function testRaisesExceptionOnInvocationIfNoRouteProvidedAndResultIndicatesFailure(): void
+    public function testReturnBasePathOnInvocationIfNoRouteProvidedAndResultIndicatesFailure(): void
     {
         $result = $this->createMock(RouteResult::class);
         $result
@@ -69,11 +69,9 @@ final class UrlHelperTest extends TestCase
 
         $helper = $this->createHelper();
         $helper->setRouteResult($result);
+        $helper->setBasePath('/foo');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('routing failed');
-
-        $helper();
+        self::assertSame('/foo', $helper());
     }
 
     public function testRaisesExceptionOnInvocationIfRouterCannotGenerateUriForRouteProvided(): void


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description

 Invoking UrlHelper while on an invalid route will lead to a RuntimeException being thrown, which in the case of laminas/getlaminas.org will prevent the error page from being rendered altogether (as mentioned in [#191 of getlaminas.org](https://github.com/laminas/getlaminas.org/issues/191), which was the starting point for this PR).
 In getlaminas' case, the exception is triggered by calling `$this->url()` in the [navigation partial](https://github.com/laminas/getlaminas.org/blob/master/templates/partials/navigation.phtml#L22) when accessing a nonexistent route.

One potential fix  would be preventing this exception from being thrown and returning the valid base url, as implemented in this PR. However, it would be a BC break for anyone trusting this exception to be thrown.

There are multiple ways to fix this problem, in different repositories - maybe by handling the exception in [mezzio/mezzio's NotFoundHandler](https://github.com/mezzio/mezzio/blob/3.20.x/src/Handler/NotFoundHandler.php#L83), or in getlaminas.org itself.  I am open to suggestions on how else to handle this issue.
