### PR TITLE
`UrlHelper`: couple its state to the `Request` only

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.10.1@f9fd6bc117e9ce1e854c2ed6777e7135aaa4966b">
+<files psalm-version="6.13.1@1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51">
   <file src="src/BodyParams/JsonStrategy.php">
     <MixedAssignment>
       <code><![CDATA[$parsedBody]]></code>
@@ -11,14 +11,23 @@
     </MixedAssignment>
   </file>
   <file src="src/UrlHelper.php">
+    <MixedAssignment>
+      <code><![CDATA[$result]]></code>
+    </MixedAssignment>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(bool) $options['reuse_query_params']]]></code>
       <code><![CDATA[(bool) $options['reuse_result_params']]]></code>
     </RedundantCastGivenDocblockType>
   </file>
-  <file src="src/UrlHelperMiddleware.php">
-    <MixedAssignment>
-      <code><![CDATA[$result]]></code>
-    </MixedAssignment>
+  <file src="test/UrlHelperMiddlewareTest.php">
+    <DocblockTypeContradiction>
+      <code><![CDATA[assertNull]]></code>
+    </DocblockTypeContradiction>
+  </file>
+  <file src="test/UrlHelperTest.php">
+    <MissingClosureParamType>
+      <code><![CDATA[$value]]></code>
+      <code><![CDATA[$value]]></code>
+    </MissingClosureParamType>
   </file>
 </files>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -11,18 +11,10 @@
     </MixedAssignment>
   </file>
   <file src="src/UrlHelper.php">
-    <MixedAssignment>
-      <code><![CDATA[$result]]></code>
-    </MixedAssignment>
     <RedundantCastGivenDocblockType>
       <code><![CDATA[(bool) $options['reuse_query_params']]]></code>
       <code><![CDATA[(bool) $options['reuse_result_params']]]></code>
     </RedundantCastGivenDocblockType>
-  </file>
-  <file src="test/UrlHelperMiddlewareTest.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[assertNull]]></code>
-    </DocblockTypeContradiction>
   </file>
   <file src="test/UrlHelperTest.php">
     <MissingClosureParamType>

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -114,7 +114,7 @@ class UrlHelper implements UrlHelperInterface
      */
     public function setRouteResult(RouteResult $result): void
     {
-        $this->result = $result;
+        $this->setRequest($this->request->withAttribute(RouteResult::class, $result));
     }
 
     /**
@@ -136,6 +136,12 @@ class UrlHelper implements UrlHelperInterface
     public function setRequest(ServerRequestInterface $request): void
     {
         $this->request = $request;
+        $this->result  = null;
+
+        $result = $request->getAttribute(RouteResult::class);
+        if ($result instanceof RouteResult) {
+            $this->result = $result;
+        }
     }
 
     public function getRequest(): ?ServerRequestInterface

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -114,6 +114,10 @@ class UrlHelper implements UrlHelperInterface
      */
     public function setRouteResult(RouteResult $result): void
     {
+        if (null === $this->request) {
+            throw new Exception\RuntimeException('A request must be set before using this method');
+        }
+
         $this->setRequest($this->request->withAttribute(RouteResult::class, $result));
     }
 

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -33,8 +33,6 @@ class UrlHelper implements UrlHelperInterface
 
     private string $basePath = '/';
 
-    private ?RouteResult $result = null;
-
     private ?ServerRequestInterface $request = null;
 
     public function __construct(private readonly RouterInterface $router)
@@ -131,7 +129,16 @@ class UrlHelper implements UrlHelperInterface
 
     public function getRouteResult(): ?RouteResult
     {
-        return $this->result;
+        if ($this->request === null) {
+            return null;
+        }
+
+        $result = $this->request->getAttribute(RouteResult::class);
+        if (! $result instanceof RouteResult) {
+            return null;
+        }
+
+        return $result;
     }
 
     /**
@@ -140,12 +147,6 @@ class UrlHelper implements UrlHelperInterface
     public function setRequest(ServerRequestInterface $request): void
     {
         $this->request = $request;
-        $this->result  = null;
-
-        $result = $request->getAttribute(RouteResult::class);
-        if ($result instanceof RouteResult) {
-            $this->result = $result;
-        }
     }
 
     public function getRequest(): ?ServerRequestInterface

--- a/src/UrlHelperInterface.php
+++ b/src/UrlHelperInterface.php
@@ -70,6 +70,8 @@ interface UrlHelperInterface
 
     /**
      * Make the current routing result available to the helper so that it can re-use matched parameters if desired
+     *
+     * @deprecated The RouteResult should be an attribute on the Request
      */
     public function setRouteResult(RouteResult $result): void;
 }

--- a/src/UrlHelperMiddleware.php
+++ b/src/UrlHelperMiddleware.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mezzio\Helper;
 
-use Mezzio\Router\RouteResult;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -30,13 +29,6 @@ class UrlHelperMiddleware implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $this->helper->setRequest($request);
-
-        $result = $request->getAttribute(RouteResult::class, false);
-
-        if ($result instanceof RouteResult) {
-            $this->helper->setRouteResult($result);
-        }
-
         return $handler->handle($request);
     }
 }

--- a/test/UrlHelperMiddlewareTest.php
+++ b/test/UrlHelperMiddlewareTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace MezzioTest\Helper;
 
+use Laminas\Diactoros\ServerRequest;
+use Mezzio\Helper\UrlHelper;
 use Mezzio\Helper\UrlHelperInterface;
 use Mezzio\Helper\UrlHelperMiddleware;
 use Mezzio\Router\Route;
 use Mezzio\Router\RouteResult;
+use Mezzio\Router\RouterInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -102,5 +105,42 @@ final class UrlHelperMiddlewareTest extends TestCase
             ->willReturn($response);
 
         self::assertSame($response, $this->middleware->process($request, $handler));
+    }
+
+    public function testCanHandleMultipleSubsequentRequests(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $handler  = new class ($response) implements RequestHandlerInterface {
+            public function __construct(
+                private readonly ResponseInterface $response,
+            ) {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return $this->response;
+            }
+        };
+
+        $helper     = new UrlHelper($this->createMock(RouterInterface::class));
+        $middleware = new UrlHelperMiddleware($helper);
+
+        $routeResult = RouteResult::fromRoute(new Route(
+            '/my-path',
+            $this->createMock(MiddlewareInterface::class),
+        ));
+        self::assertSame($response, $middleware->process(
+            (new ServerRequest())->withAttribute(RouteResult::class, $routeResult),
+            $handler,
+        ));
+
+        self::assertSame($routeResult, $helper->getRouteResult());
+
+        self::assertSame($response, $middleware->process(
+            new ServerRequest(),
+            $handler,
+        ));
+
+        self::assertNull($helper->getRouteResult());
     }
 }

--- a/test/UrlHelperMiddlewareTest.php
+++ b/test/UrlHelperMiddlewareTest.php
@@ -86,10 +86,7 @@ final class UrlHelperMiddlewareTest extends TestCase
         $helper     = new UrlHelper($this->createMock(RouterInterface::class));
         $middleware = new UrlHelperMiddleware($helper);
 
-        $routeResult = RouteResult::fromRoute(new Route(
-            '/my-path',
-            $this->createMock(MiddlewareInterface::class),
-        ));
+        $routeResult = RouteResult::fromRouteFailure([]);
         self::assertSame($response, $middleware->process(
             (new ServerRequest())->withAttribute(RouteResult::class, $routeResult),
             $handler,

--- a/test/UrlHelperMiddlewareTest.php
+++ b/test/UrlHelperMiddlewareTest.php
@@ -36,7 +36,7 @@ final class UrlHelperMiddlewareTest extends TestCase
         $this->middleware = new UrlHelperMiddleware($this->helper);
     }
 
-    public function testInvocationInjectsHelperWithRouteResultWhenPresentInRequest(): void
+    public function testInvocationInjectsHelperWithRequest(): void
     {
         $response = $this->createMock(ResponseInterface::class);
 
@@ -47,49 +47,10 @@ final class UrlHelperMiddlewareTest extends TestCase
 
         $request = $this->createMock(ServerRequestInterface::class);
 
-        $request
-            ->expects(self::once())
-            ->method('getAttribute')
-            ->with(RouteResult::class, false)
-            ->willReturn($routeResult);
-
-        $this->helper
-            ->expects(self::once())
-            ->method('setRouteResult')
-            ->with($routeResult);
-
-        $this->helper
-            ->expects(self::once())
-            ->method('setRequest')
-            ->with($request);
-
-        $handler = $this->createMock(RequestHandlerInterface::class);
-
-        $handler
-            ->expects(self::once())
-            ->method('handle')
-            ->with($request)
-            ->willReturn($response);
-
-        self::assertSame($response, $this->middleware->process($request, $handler));
-    }
-
-    public function testInvocationDoesNotInjectHelperWithRouteResultWhenAbsentInRequest(): void
-    {
-        $response = $this->createMock(ResponseInterface::class);
-
-        $request = $this->createMock(ServerRequestInterface::class);
-
-        $request
-            ->expects(self::once())
-            ->method('getAttribute')
-            ->with(RouteResult::class, false)
-            ->willReturn(false);
-
         $this->helper
             ->expects(self::never())
             ->method('setRouteResult')
-            ->with(self::anything());
+            ->with($routeResult);
 
         $this->helper
             ->expects(self::once())

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -216,15 +216,6 @@ final class UrlHelperTest extends TestCase
         self::assertSame('URL', ($this->helper)('resource', [], [], null, ['reuse_result_params' => false]));
     }
 
-    public function testCanInjectRouteResult(): void
-    {
-        $result = $this->generateRouteResult(false, '/foo', 'resource', ['id' => 1]);
-
-        $this->helper->setRequest($this->createRequest($result));
-
-        self::assertAttributeSame($result, 'result', $this->helper);
-    }
-
     public function testAllowsSettingBasePath(): void
     {
         $this->helper->setBasePath('/foo');

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -28,37 +28,45 @@ final class UrlHelperTest extends TestCase
 
     /** @var RouterInterface&MockObject */
     private RouterInterface $router;
+    private UrlHelper $helper;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->router = $this->createMock(RouterInterface::class);
+        $this->helper = new UrlHelper($this->router);
     }
 
-    public function createHelper(): UrlHelper
+    private function createRequest(?RouteResult $routeResult): ServerRequestInterface&MockObject
     {
         $request = $this->createMock(ServerRequestInterface::class);
 
         $request
-            ->expects(self::never())
-            ->method('getQueryParams')
-            ->willReturn([]);
+            ->expects(self::any())
+            ->method('getAttribute')
+            ->with($this->identicalTo(RouteResult::class))
+            ->willReturn($routeResult);
 
-        $helper = new UrlHelper($this->router);
-        $helper->setRequest($request);
+        $request
+            ->expects(self::any())
+            ->method('withAttribute')
+            ->willReturnCallback(function (string $name, $value): ServerRequestInterface {
+                self::assertSame(RouteResult::class, $name);
+                self::assertInstanceOf(RouteResult::class, $value);
 
-        return $helper;
+                return $this->createRequest($value);
+            });
+
+        return $request;
     }
 
     public function testRaisesExceptionOnInvocationIfNoRouteProvidedAndNoResultPresent(): void
     {
-        $helper = $this->createHelper();
-
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('use matched result');
 
-        $helper();
+        ($this->helper)();
     }
 
     /**
@@ -86,13 +94,12 @@ final class UrlHelperTest extends TestCase
     public function testRaisesExceptionOnInvocationIfNoRouteProvidedAndResultIndicatesFailure(): void
     {
         $result = $this->generateRouteResult(true);
-        $helper = $this->createHelper();
-        $helper->setRouteResult($result);
+        $this->helper->setRequest($this->createRequest($result));
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('routing failed');
 
-        $helper();
+        ($this->helper)();
     }
 
     public function testRaisesExceptionOnInvocationIfRouterCannotGenerateUriForRouteProvided(): void
@@ -103,11 +110,9 @@ final class UrlHelperTest extends TestCase
             ->with('foo', [], [])
             ->willThrowException(new RouterException());
 
-        $helper = $this->createHelper();
-
         $this->expectException(RouterException::class);
 
-        $helper('foo');
+        ($this->helper)('foo');
     }
 
     public function testWhenNoRouteProvidedTheHelperUsesComposedResultToGenerateUrl(): void
@@ -120,10 +125,9 @@ final class UrlHelperTest extends TestCase
             ->with('foo', ['bar' => 'baz'], [])
             ->willReturn('URL');
 
-        $helper = $this->createHelper();
-        $helper->setRouteResult($result);
+        $this->helper->setRequest($this->createRequest($result));
 
-        self::assertSame('URL', $helper());
+        self::assertSame('URL', ($this->helper)());
     }
 
     public function testWhenNoRouteProvidedTheHelperMergesPassedParametersWithResultParametersToGenerateUrl(): void
@@ -136,10 +140,9 @@ final class UrlHelperTest extends TestCase
             ->with('foo', ['bar' => 'baz', 'baz' => 'bat'], [])
             ->willReturn('URL');
 
-        $helper = $this->createHelper();
-        $helper->setRouteResult($result);
+        $this->helper->setRequest($this->createRequest($result));
 
-        self::assertSame('URL', $helper(null, ['baz' => 'bat']));
+        self::assertSame('URL', ($this->helper)(null, ['baz' => 'bat']));
     }
 
     public function testWhenRouteProvidedTheHelperDelegatesToTheRouterToGenerateUrl(): void
@@ -150,9 +153,7 @@ final class UrlHelperTest extends TestCase
             ->with('foo', ['bar' => 'baz'], [])
             ->willReturn('URL');
 
-        $helper = $this->createHelper();
-
-        self::assertSame('URL', $helper('foo', ['bar' => 'baz']));
+        self::assertSame('URL', ($this->helper)('foo', ['bar' => 'baz']));
     }
 
     public function testIfRouteResultRouteNameDoesNotMatchRequestedNameItWillNotMergeParamsToGenerateUri(): void
@@ -165,10 +166,9 @@ final class UrlHelperTest extends TestCase
             ->with('resource', [], [])
             ->willReturn('URL');
 
-        $helper = $this->createHelper();
-        $helper->setRouteResult($result);
+        $this->helper->setRequest($this->createRequest($result));
 
-        self::assertSame('URL', $helper('resource'));
+        self::assertSame('URL', ($this->helper)('resource'));
     }
 
     public function testMergesRouteResultParamsWithProvidedParametersToGenerateUri(): void
@@ -181,10 +181,9 @@ final class UrlHelperTest extends TestCase
             ->with('resource', ['id' => 1, 'version' => 2], [])
             ->willReturn('URL');
 
-        $helper = $this->createHelper();
-        $helper->setRouteResult($result);
+        $this->helper->setRequest($this->createRequest($result));
 
-        self::assertSame('URL', $helper('resource', ['version' => 2]));
+        self::assertSame('URL', ($this->helper)('resource', ['version' => 2]));
     }
 
     public function testProvidedParametersOverrideAnyPresentInARouteResultWhenGeneratingUri(): void
@@ -197,10 +196,9 @@ final class UrlHelperTest extends TestCase
             ->with('resource', ['id' => 2], [])
             ->willReturn('URL');
 
-        $helper = $this->createHelper();
-        $helper->setRouteResult($result);
+        $this->helper->setRequest($this->createRequest($result));
 
-        self::assertSame('URL', $helper('resource', ['id' => 2]));
+        self::assertSame('URL', ($this->helper)('resource', ['id' => 2]));
     }
 
     public function testWillNotReuseRouteResultParamsIfReuseResultParamsFlagIsFalseWhenGeneratingUri(): void
@@ -213,36 +211,32 @@ final class UrlHelperTest extends TestCase
             ->with('resource', [], [])
             ->willReturn('URL');
 
-        $helper = $this->createHelper();
-        $helper->setRouteResult($result);
+        $this->helper->setRequest($this->createRequest($result));
 
-        self::assertSame('URL', $helper('resource', [], [], null, ['reuse_result_params' => false]));
+        self::assertSame('URL', ($this->helper)('resource', [], [], null, ['reuse_result_params' => false]));
     }
 
     public function testCanInjectRouteResult(): void
     {
         $result = $this->generateRouteResult(false, '/foo', 'resource', ['id' => 1]);
 
-        $helper = $this->createHelper();
-        $helper->setRouteResult($result);
+        $this->helper->setRequest($this->createRequest($result));
 
-        self::assertAttributeSame($result, 'result', $helper);
+        self::assertAttributeSame($result, 'result', $this->helper);
     }
 
     public function testAllowsSettingBasePath(): void
     {
-        $helper = $this->createHelper();
-        $helper->setBasePath('/foo');
+        $this->helper->setBasePath('/foo');
 
-        self::assertAttributeEquals('/foo', 'basePath', $helper);
+        self::assertAttributeEquals('/foo', 'basePath', $this->helper);
     }
 
     public function testSlashIsPrependedWhenBasePathDoesNotHaveOne(): void
     {
-        $helper = $this->createHelper();
-        $helper->setBasePath('foo');
+        $this->helper->setBasePath('foo');
 
-        self::assertAttributeEquals('/foo', 'basePath', $helper);
+        self::assertAttributeEquals('/foo', 'basePath', $this->helper);
     }
 
     public function testBasePathIsPrependedToGeneratedPath(): void
@@ -253,10 +247,9 @@ final class UrlHelperTest extends TestCase
             ->with('foo', ['bar' => 'baz'], [])
             ->willReturn('/foo/baz');
 
-        $helper = $this->createHelper();
-        $helper->setBasePath('/prefix');
+        $this->helper->setBasePath('/prefix');
 
-        self::assertSame('/prefix/foo/baz', $helper('foo', ['bar' => 'baz']));
+        self::assertSame('/prefix/foo/baz', ($this->helper)('foo', ['bar' => 'baz']));
     }
 
     public function testBasePathIsPrependedToGeneratedPathWhenUsingRouteResult(): void
@@ -269,15 +262,14 @@ final class UrlHelperTest extends TestCase
             ->with('foo', ['bar' => 'baz'], [])
             ->willReturn('/foo/baz');
 
-        $helper = $this->createHelper();
-        $helper->setBasePath('/prefix');
-        $helper->setRouteResult($result);
+        $this->helper->setBasePath('/prefix');
+        $this->helper->setRequest($this->createRequest($result));
 
         // test with explicit params
-        self::assertSame('/prefix/foo/baz', $helper(null, ['bar' => 'baz']));
+        self::assertSame('/prefix/foo/baz', ($this->helper)(null, ['bar' => 'baz']));
 
         // test with implicit route result params
-        self::assertSame('/prefix/foo/baz', $helper());
+        self::assertSame('/prefix/foo/baz', ($this->helper)());
     }
 
     public function testGenerateAndInvokeMethodProduceTheSameResult(): void
@@ -288,10 +280,9 @@ final class UrlHelperTest extends TestCase
         $fragmentIdentifier = 'foobar';
         $options            = ['router' => ['foobar' => 'baz'], 'reuse_result_params' => false];
 
-        $helper = $this->createHelper();
         self::assertSame(
-            $helper->__invoke($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options),
-            $helper->generate($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options),
+            $this->helper->__invoke($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options),
+            $this->helper->generate($routeName, $routeParams, $queryParams, $fragmentIdentifier, $options),
         );
     }
 
@@ -309,9 +300,8 @@ final class UrlHelperTest extends TestCase
     {
         $this->expectException(TypeError::class);
 
-        $helper = $this->createHelper();
         /** @psalm-suppress MixedArgument */
-        $helper->setBasePath($basePath);
+        $this->helper->setBasePath($basePath);
     }
 
     public function testIfRouteResultIsFailureItWillNotMergeParamsToGenerateUri(): void
@@ -324,10 +314,9 @@ final class UrlHelperTest extends TestCase
             ->with('resource', [], [])
             ->willReturn('URL');
 
-        $helper = $this->createHelper();
-        $helper->setRouteResult($result);
+        $this->helper->setRequest($this->createRequest($result));
 
-        self::assertSame('URL', $helper('resource'));
+        self::assertSame('URL', ($this->helper)('resource'));
     }
 
     public function testOptionsArePassedToRouter(): void
@@ -338,9 +327,7 @@ final class UrlHelperTest extends TestCase
             ->with('foo', [], ['bar' => 'baz'])
             ->willReturn('URL');
 
-        $helper = $this->createHelper();
-
-        self::assertSame('URL', $helper('foo', [], [], null, ['router' => ['bar' => 'baz']]));
+        self::assertSame('URL', ($this->helper)('foo', [], [], null, ['router' => ['bar' => 'baz']]));
     }
 
     /** @return array<string, array{0: array<string, mixed>, 1: string|null, 2: string}> */
@@ -369,11 +356,9 @@ final class UrlHelperTest extends TestCase
             ->with('foo', ['bar' => 'baz'], [])
             ->willReturn('/foo/baz');
 
-        $helper = $this->createHelper();
-
         self::assertSame(
             '/foo/baz' . $expected,
-            $helper('foo', ['bar' => 'baz'], $queryParams, $fragmentIdentifier),
+            ($this->helper)('foo', ['bar' => 'baz'], $queryParams, $fragmentIdentifier),
         );
     }
 
@@ -389,18 +374,17 @@ final class UrlHelperTest extends TestCase
     #[DataProvider('invalidFragmentProvider')]
     public function testRejectsInvalidFragmentIdentifier(string $fragmentIdentifier): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Fragment identifier must conform to RFC 3986');
-        $this->expectExceptionCode(400);
-
         $this->router
             ->expects(self::once())
             ->method('generateUri')
             ->with('foo', [], [])
             ->willReturn('/foo');
 
-        $helper = $this->createHelper();
-        $helper('foo', [], [], $fragmentIdentifier);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Fragment identifier must conform to RFC 3986');
+        $this->expectExceptionCode(400);
+
+        ($this->helper)('foo', [], [], $fragmentIdentifier);
     }
 
     /**
@@ -415,9 +399,7 @@ final class UrlHelperTest extends TestCase
             ->with('foo', [], [])
             ->willReturn('/foo');
 
-        $helper = $this->createHelper();
-
-        self::assertSame('/foo', $helper->generate('foo'));
+        self::assertSame('/foo', ($this->helper)->generate('foo'));
     }
 
     #[Group('42')]
@@ -431,12 +413,11 @@ final class UrlHelperTest extends TestCase
             ->with('matched-route', ['foo' => 'baz'], [])
             ->willReturn('scheme://host/path');
 
-        $helper = $this->createHelper();
-        $helper->setRouteResult($result);
+        $this->helper->setRequest($this->createRequest($result));
 
         self::assertSame(
             'scheme://host/path?query=params&are=present#fragment/exists',
-            $helper(
+            ($this->helper)(
                 null,
                 ['foo' => 'baz'],
                 ['query' => 'params', 'are' => 'present'],
@@ -447,19 +428,16 @@ final class UrlHelperTest extends TestCase
 
     public function testGetRouteResultIfNoRouteResultSet(): void
     {
-        $helper = $this->createHelper();
-
-        self::assertNull($helper->getRouteResult());
+        self::assertNull($this->helper->getRouteResult());
     }
 
     public function testGetRouteResultWithRouteResultSet(): void
     {
         $result = $this->generateRouteResult(false);
 
-        $helper = $this->createHelper();
-        $helper->setRouteResult($result);
+        $this->helper->setRequest($this->createRequest($result));
 
-        self::assertSame($result, $helper->getRouteResult());
+        self::assertSame($result, $this->helper->getRouteResult());
     }
 
     public function testWillNotReuseQueryParamsIfReuseQueryParamsFlagIsFalseWhenGeneratingUri(): void
@@ -478,11 +456,9 @@ final class UrlHelperTest extends TestCase
             ->expects(self::never())
             ->method('getQueryParams');
 
-        $helper = $this->createHelper();
-        $helper->setRouteResult($result);
-        $helper->setRequest($request);
+        $this->helper->setRequest($this->createRequest($result));
 
-        self::assertSame('URL', $helper('resource', [], [], null, ['reuse_query_params' => false]));
+        self::assertSame('URL', ($this->helper)('resource', [], [], null, ['reuse_query_params' => false]));
     }
 
     public function testWillReuseQueryParamsIfReuseQueryParamsFlagIsTrueWhenGeneratingUri(): void
@@ -495,18 +471,16 @@ final class UrlHelperTest extends TestCase
             ->with('resource', [], [])
             ->willReturn('URL');
 
-        $request = $this->createMock(ServerRequestInterface::class);
+        $request = $this->createRequest($result);
 
         $request
             ->expects(self::once())
             ->method('getQueryParams')
             ->wilLReturn(['foo' => 'bar']);
 
-        $helper = $this->createHelper();
-        $helper->setRouteResult($result);
-        $helper->setRequest($request);
+        $this->helper->setRequest($request);
 
-        self::assertSame('URL?foo=bar', $helper('resource', [], [], null, ['reuse_query_params' => true]));
+        self::assertSame('URL?foo=bar', ($this->helper)('resource', [], [], null, ['reuse_query_params' => true]));
     }
 
     public function testWillNotReuseQueryParamsIfReuseQueryParamsFlagIsMissingGeneratingUri(): void
@@ -519,17 +493,15 @@ final class UrlHelperTest extends TestCase
             ->with('resource', [], [])
             ->willReturn('URL');
 
-        $request = $this->createMock(ServerRequestInterface::class);
+        $request = $this->createRequest($result);
 
         $request
             ->expects(self::never())
             ->method('getQueryParams');
 
-        $helper = $this->createHelper();
-        $helper->setRouteResult($result);
-        $helper->setRequest($request);
+        $this->helper->setRequest($request);
 
-        self::assertSame('URL', $helper('resource'));
+        self::assertSame('URL', ($this->helper)('resource'));
     }
 
     public function testCanOverrideRequestQueryParams(): void
@@ -542,16 +514,14 @@ final class UrlHelperTest extends TestCase
             ->with('resource', [], [])
             ->willReturn('URL');
 
-        $request = $this->createMock(ServerRequestInterface::class);
+        $request = $this->createRequest($result);
 
         $request
             ->expects(self::never())
             ->method('getQueryParams');
 
-        $helper = $this->createHelper();
-        $helper->setRouteResult($result);
-        $helper->setRequest($request);
+        $this->helper->setRequest($request);
 
-        self::assertSame('URL?foo=foo', $helper('resource', [], ['foo' => 'foo']));
+        self::assertSame('URL?foo=foo', ($this->helper)('resource', [], ['foo' => 'foo']));
     }
 }

--- a/test/UrlHelperTest.php
+++ b/test/UrlHelperTest.php
@@ -524,4 +524,37 @@ final class UrlHelperTest extends TestCase
 
         self::assertSame('URL?foo=foo', ($this->helper)('resource', [], ['foo' => 'foo']));
     }
+
+    public function testSetRouteResultRequireTheRequestToBePreviouslySet(): void
+    {
+        $result = $this->generateRouteResult(true);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+
+        $request
+            ->expects(self::once())
+            ->method('withAttribute')
+            ->willReturnCallback(function (string $name, $value) use ($result): ServerRequestInterface {
+                self::assertSame(RouteResult::class, $name);
+                self::assertSame($result, $value);
+
+                return $this->createRequest($value);
+            });
+
+        $this->helper->setRequest($request);
+        $this->helper->setRouteResult($result);
+
+        self::assertSame($result, $this->helper->getRouteResult());
+        self::assertNotSame($request, $this->helper->getRequest());
+    }
+
+    public function testSetRouteResultApiSetsANewRequestWithAttributeSet(): void
+    {
+        $result = $this->generateRouteResult(true);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('A request must be set before using this method');
+
+        $this->helper->setRouteResult($result);
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Hello, I'm trying to get Mezzio working with a web server that handles multiple requests per process (FrankenPHP in `worker` mode) and I noticed that the `UrlHelper` has 2 stateful and factually unrelated attributes:

- the `Request`
- the `RouteResult`

While the former is logical and correct, the latter depends from the `Request` but has the separate API `setRouteResult` that can be used without keeping the relative request aligned.

The result is that this simple test fails:

https://github.com/Slamdunk/mezzio-helpers/blob/669e33a729a17fd65abf05afc8836b0b1cbb8e73/test/UrlHelperMiddlewareTest.php#L89-L102

This PR proposes to `@deprecate` the `setRouteResult` API and require the `RouteResult` to be an attribute of the `Request`, which already is in the Mezzio ecosystem and prevents any cross-request leak.